### PR TITLE
issues#4 sche_each_time create

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,12 @@ gem 'activeadmin', github: 'gregbell/active_admin'
 
 gem 'jquery-turbolinks'
 
+gem 'cocoon'
+
+gem 'google_places'
+
+gem 'jc-validates_timeliness'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
       mime-types (>= 1.16)
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
+    cocoon (1.2.11)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -325,6 +326,8 @@ GEM
       momentjs-rails (>= 2.9.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    google_places (1.0.0)
+      httparty (>= 0.13.1)
     gretel (3.0.9)
       rails (>= 3.1.0)
     has_scope (0.7.1)
@@ -333,6 +336,8 @@ GEM
     hirb (0.7.3)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    httparty (0.15.6)
+      multi_xml (>= 0.5.2)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     inflecto (0.0.2)
@@ -345,6 +350,8 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jc-validates_timeliness (3.1.1)
+      timeliness (~> 0.3.7)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -394,6 +401,7 @@ GEM
     momentjs-rails (2.17.1)
       railties (>= 3.1)
     multi_json (1.12.2)
+    multi_xml (0.6.0)
     netrc (0.11.0)
     nio4r (2.1.0)
     nokogiri (1.8.1)
@@ -507,6 +515,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timeliness (0.3.8)
     trollop (2.1.2)
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
@@ -547,6 +556,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   carrierwave
+  cocoon
   coffee-rails (~> 4.2)
   config
   devise
@@ -556,9 +566,11 @@ DEPENDENCIES
   fog
   font-awesome-rails
   fullcalendar-rails
+  google_places
   gretel
   hirb
   jbuilder (~> 2.5)
+  jc-validates_timeliness
   jquery-rails
   jquery-turbolinks
   kaminari

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery
 //= require jquery.turbolinks
 //= require turbolinks
+//= require cocoon
 //= require moment
 //= require fullcalendar
 //= require calendar

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -48,7 +48,7 @@ $(document).on('turbolinks:load',function() {
     allDayText:'',                   // 終日スロットのタイトル
     eventClick: function(event) { //イベントをクリックしたときに実行
       var id = event.id
-      var show_url = "schedule_each_date_time/"+id
+      var show_url = "travel_planning_time/"+id
       location.href = show_url;
     }
    });

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,5 @@
 @import "bootstrap";
 @import "font-awesome";
 @import "rails_bootstrap_forms";
+@import "common";
+@import "schedule_each_time";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,0 +1,3 @@
+#error_explanation {
+  color: #ff0000;
+}

--- a/app/assets/stylesheets/schedule_each_time.scss
+++ b/app/assets/stylesheets/schedule_each_time.scss
@@ -1,0 +1,3 @@
+.nested-fields {
+  margin: 10px 0px;
+}

--- a/app/controllers/spot_search_controller.rb
+++ b/app/controllers/spot_search_controller.rb
@@ -1,0 +1,48 @@
+class SpotSearchController < ApplicationController
+  before_action :set_spot, only: [:show, :destroy, :select]
+  def index
+    @spots = Spot.all
+  end
+
+  def list
+    keyword = params[:search]
+    @client = GooglePlaces::Client.new( ENV['GOOGLE_API_KEY'] )
+    @spots = @client.spots_by_query( keyword )
+  end
+
+  def show
+  end
+
+  def select
+      render file: "/layouts/closed_and_reloaded", locals: {spot: @spot }, layout: false
+  end
+
+  def create
+   @spot = Spot.new(spot_params)
+
+   respond_to do |format|
+     if @spot.save
+       format.html { redirect_to spot_search_index_path, notice: "#{@spot.name} の位置情報を保存しました" }
+     else
+       format.html { render :index, notice: "#{@spot.name} の位置情報を保存できませんでした" }
+     end
+   end
+ end
+
+ def destroy
+   @spot.destroy
+
+   respond_to do |format|
+     format.html { redirect_to spot_search_index_path, notice: "#{@spot.name} の位置情報を削除しました" }
+   end
+ end
+
+  private
+    def set_spot
+      @spot = Spot.find(params[:id])
+    end
+
+    def spot_params
+      params.require(:spot).permit(:name, :latitude, :longitude, :address)
+    end
+end

--- a/app/controllers/travel_planning_time_controller.rb
+++ b/app/controllers/travel_planning_time_controller.rb
@@ -1,0 +1,30 @@
+class TravelPlanningTimeController < ApplicationController
+  before_action :set_schedule_date, only: [:show,:edit, :update, :destroy]
+  def show
+    getSpotAll
+  end
+
+  def update
+    if @schedule_each_date.update(schedule_date_params)
+      flash[:success] = "スケジュールを更新しました"
+      redirect_to travel_planning_time_path
+    else
+      getSpotAll
+      render :show
+    end
+  end
+
+  private
+  #マスタテーブル該当データを表示させるため、場所名をセレクトボックスで全件入れて準備
+  def getSpotAll
+    @spots = Spot.all.pluck(:name, :id)
+    @spots.unshift(["選択してください。", ""])
+  end
+  #対象のスケジュール日付とその日付に紐付く時間帯データも合わせて取得
+  def set_schedule_date
+      @schedule_each_date = ScheduleEachDate.includes(:schedule_each_times).order("schedule_each_times.from_time,schedule_each_times.to_time").find(params[:id])
+  end
+  def schedule_date_params
+       params.require(:schedule_each_date).permit(:id,:user_id,:schedule_id, schedule_each_times_attributes: [:id,:from_time,:to_time,:place_id,:user_id,:schedule_id,:memo,:_destroy])
+  end
+end

--- a/app/models/schedule_each_date.rb
+++ b/app/models/schedule_each_date.rb
@@ -1,5 +1,7 @@
 class ScheduleEachDate < ApplicationRecord
   belongs_to :schedule
+  has_many :schedule_each_times, dependent: :destroy, inverse_of: :schedule_each_date
+  accepts_nested_attributes_for :schedule_each_times, reject_if: :all_blank, allow_destroy: true
   validates :sche_date, presence: true
 
 end

--- a/app/models/schedule_each_time.rb
+++ b/app/models/schedule_each_time.rb
@@ -1,0 +1,7 @@
+class ScheduleEachTime < ApplicationRecord
+  belongs_to :schedule_each_date
+  validates_associated :schedule_each_date
+  validates :from_time, presence: true, sche_time: true
+  validates :to_time, presence: true
+  validates_time :to_time, :after => :from_time
+end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,0 +1,2 @@
+class Spot < ApplicationRecord
+end

--- a/app/validators/sche_time_validator.rb
+++ b/app/validators/sche_time_validator.rb
@@ -1,0 +1,16 @@
+class ScheTimeValidator < ActiveModel::EachValidator
+  private def validate_each(record, attribute, value)
+    #今回対象としているスケジュールの日付内で、登録または更新対象のスケジュール時間帯別以外のデータを取得
+    @schedule_each_times = ScheduleEachTime.where(schedule_id: record['schedule_id'],schedule_each_date_id: record['schedule_each_date_id'],user_id: record['user_id']).where.not(id: record['id']).order(:from_time)
+    #登録・更新対象のスケジュール時刻と周辺スケジュール時刻不整合チェック
+    @schedule_each_times.each do |schedule_each_times|
+      #今回修正対象のto_timeが既存のデータにあるfrom_time以上になるレコードをチェック対象とする
+      if record['to_time'].strftime("%H:%M") >= schedule_each_times.from_time.strftime("%H:%M")
+        #今回修正レコードのfrom_timeが比較対象のto_timeより小さければ、不整合でエラー
+        if record['from_time'].strftime("%H:%M") < schedule_each_times.to_time.strftime("%H:%M")
+          record.errors.add(attribute, "を、対象スケジュールの前のスケジュール滞在終了時刻よりも以降の時刻を入力してください。")
+        end
+      end
+    end
+  end
+end

--- a/app/views/layouts/closed_and_reloaded.html.erb
+++ b/app/views/layouts/closed_and_reloaded.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html PUBLIC -//W3C//DTD XHTML 1.0 Transitional//EN http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd>
+<html>
+  <body>
+    <script>
+      var place_id = localStorage.getItem('place_id');
+      window.opener.document.getElementsByName(place_id)[0].value = <%= spot.id %>;
+      window.opener.document.getElementsByName(place_id)[1].value = <%= spot.id %>;
+      localStorage.removeItem('place_id')
+      window.close();
+    </script>
+  </body>
+</html>

--- a/app/views/spot_search/index.html.erb
+++ b/app/views/spot_search/index.html.erb
@@ -1,0 +1,46 @@
+<h1>スポット検索</h1>
+
+<div class="col-md-6">
+  <%= form_tag list_spot_search_index_path, :role =>"form", :method => :get do %>
+    <div class="form-group">
+      <%= text_field_tag :search, params[:search], { :class => "form-control", :required => true, } %>
+      <%= button_tag( {:type => "submit", :name => nil, :class => "btn btn-default" } ) do %>
+        <span class="glyphicon glyphicon-search">キーワード検索</span>
+      <% end %>
+    </div>
+  <% end %>
+</div>
+
+<div class="col-md-12">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Latitude</th>
+        <th>Longitude</th>
+        <th>Address</th>
+        <th colspan="2"></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @spots.each do |spot| %>
+        <tr>
+          <td><%= spot.name %></td>
+          <td><%= spot.latitude %></td>
+          <td><%= spot.longitude %></td>
+          <td><%= spot.address %></td>
+          <td><%= link_to ( spot_search_path(spot)), :title => "show" do %>
+            <span class="glyphicon glyphicon-stats"></span>
+          <% end %></td>
+          <td><%= link_to( spot_search_path(spot), method: :delete, data: { confirm: "#{spot.name} の位置情報を削除します" }, :title => "delete" ) do %>
+            <span class="glyphicon glyphicon-trash"></span>
+          <% end %></td>
+          <td><%= link_to select_spot_search_path(spot) do %>
+            <span class="glyphicon glyphicon-save-file" aria-hidden="true"></span>
+          <% end %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/spot_search/list.html.erb
+++ b/app/views/spot_search/list.html.erb
@@ -1,0 +1,36 @@
+<h1>スポット検索結果</h1>
+
+<div class="col-md-12">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Latitude</th>
+        <th>Longitude</th>
+        <th>Address</th>
+        <th></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @spots.each do |spot| %>
+        <tr>
+          <td><%= spot.name %></td>
+          <td><%= spot.lat %></td>
+          <td><%= spot.lng %></td>
+          <td><%= spot.formatted_address %></td>
+          <td><%= link_to( '登録', spot_search_index_path( :spot => { :name      => spot.name,
+                                                                 :latitude  => spot.lat,
+                                                                 :longitude => spot.lng,
+                                                                 :address   => spot.formatted_address, } ),:method => 'post' ) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  <button type="button" class="btn pull-right btn-lg btn-default">
+    <%= link_to 'Back', spot_search_index_path %>
+  </button>
+
+</div>

--- a/app/views/spot_search/show.html.erb
+++ b/app/views/spot_search/show.html.erb
@@ -1,0 +1,25 @@
+<div class="col-md-12">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Latitude</th>
+        <th>Longitude</th>
+        <th>Address</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= @spot.name %></td>
+        <td><%= @spot.latitude %></td>
+        <td><%= @spot.longitude %></td>
+        <td><%= @spot.address %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <button type="button" class="btn pull-right btn-lg btn-default">
+    <%= link_to '戻る', spot_search_index_path %>
+  </button>
+
+</div>

--- a/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
+++ b/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
@@ -1,0 +1,24 @@
+<div class='nested-fields'>
+  <%= f.hidden_field :user_id, :value => @schedule_each_date.user_id %>
+  <%= f.hidden_field :schedule_id, :value => @schedule_each_date.schedule_id %>
+
+    <div class="field">
+      <%= f.label :from_time, "滞在開始時間" %>
+      <%= f.time_select :from_time %>〜
+      <%= f.label :to_time, "滞在終了時間" %>
+      <%= f.time_select :to_time %>
+    </div>
+    <div class="field">
+      <%= f.label :memo, "メモ" %>
+      <%= f.text_field :memo %>　
+      <%= f.label :place_id, "場所" %>
+      <%= f.select :place_id, @spots, {}, :disabled => true %>
+      <%= f.hidden_field :place_id %>
+      <%= link_to '場所名を選択する', spot_search_index_path, :onclick => "
+      var prevElement1 = event.target.previousElementSibling;
+      var place_id = prevElement1.getAttribute('name');
+      localStorage.setItem('place_id', place_id);
+      window.open(this.href, 'height=800, width=800');return false;"  %>
+    </div>
+    <%= link_to_remove_association "このスケジュールを削除する", f %>
+</div>

--- a/app/views/travel_planning_time/show.html.erb
+++ b/app/views/travel_planning_time/show.html.erb
@@ -1,0 +1,41 @@
+<div class="row">
+  <div class="row">
+    <div class="col-md-4 col-md-push-6 text-center"><h2>旅行スケジュール時間帯別作成</h2></div>
+  </div>
+  <aside class="col-md-4">
+    <!-- サイドパネル設置予定 -->
+  </aside>
+  <div class="col-md-8">
+    <% flash_messages %>
+      <% if @schedule_each_date.errors.any? %>
+      <div id="error_explanation">
+        <h4><%= @schedule_each_date.errors.count %>件のエラーがあります。</h4>
+        <ul>
+        <% @schedule_each_date.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <%= form_for @schedule_each_date, :url => {:controller => :travel_planning_time, :action => :update} do |f| %>
+      <div class="field">
+        <ol>
+          <%= f.fields_for :schedule_each_times do |schedule_each_time| %>
+            <li>
+              <%= render 'schedule_each_time_fields', :f => schedule_each_time,schedule_each_date: @schedule_each_date ,
+              schedule_each_time: schedule_each_time %>
+            </li>
+            <p>
+              <%= link_to_add_association "スケジュールを追加",f, :schedule_each_times %>
+            </p>
+          <% end %>
+        </ol>
+        <div class="actions">
+          <%= f.submit "登録する" %>
+        </div>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,13 +17,17 @@ module OriginalApp
       g.helper false
       g.stylesheets false
     end
-
+    config.active_record.default_timezone = :local
+    
     config.i18n.default_locale = :ja
 
     config.time_zone = 'Tokyo'
     # add custom validators path
     config.autoload_paths += Dir["#{config.root}/app/validators"]
-    
+
+    config.action_view.field_error_proc = Proc.new do |html_tag, instance|
+      %Q(#{html_tag}).html_safe
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/initializers/validates_timeliness.rb
+++ b/config/initializers/validates_timeliness.rb
@@ -1,0 +1,40 @@
+ValidatesTimeliness.setup do |config|
+  # Extend ORM/ODMs for full support (:active_record, :mongoid).
+  # config.extend_orms = [ :active_record ]
+  #
+  # Default timezone
+  # config.default_timezone = :utc
+  #
+  # Set the dummy date part for a time type values.
+  # config.dummy_date_for_time_type = [ 2000, 1, 1 ]
+  #
+  # Ignore errors when restriction options are evaluated
+  # config.ignore_restriction_errors = false
+  #
+  # Re-display invalid values in date/time selects
+  # config.enable_date_time_select_extension!
+  #
+  # Handle multiparameter date/time values strictly
+  # config.enable_multiparameter_extension!
+  #
+  # Shorthand date and time symbols for restrictions
+  # config.restriction_shorthand_symbols.update(
+  #   :now   => lambda { Time.current },
+  #   :today => lambda { Date.current }
+  # )
+  #
+  # Use the plugin date/time parser which is stricter and extendable
+  # config.use_plugin_parser = false
+  #
+  # Add one or more formats making them valid. e.g. add_formats(:date, 'd(st|rd|th) of mmm, yyyy')
+  # config.parser.add_formats()
+  #
+  # Remove one or more formats making them invalid. e.g. remove_formats(:date, 'dd/mm/yyy')
+  # config.parser.remove_formats()
+  #
+  # Change the amiguous year threshold when parsing a 2 digit year
+  # config.parser.ambiguous_year_threshold =  30
+  #
+  # Treat ambiguous dates, such as 01/02/1950, as a Non-US date.
+  # config.parser.remove_us_formats
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,12 +5,17 @@ ja:
       admin_user: 管理者
       comment: コメント
       name: 名前
+      schedule_each_date: スケジュール日付別
+      schedule_each_time: スケジュール時間帯別
     attributes:
       admin_user:
         email: メールアドレス
         current_sign_in_at: 最新ログイン日時
         sign_in_count: ログイン回数
         created_at: 作成日時
+      schedule_each_date/schedule_each_times:
+        from_time: 滞在開始時間
+        to_time: 滞在終了時間
       name:
         name: 名前
         date: 日付

--- a/config/locales/validates_timeliness.en.yml
+++ b/config/locales/validates_timeliness.en.yml
@@ -1,0 +1,16 @@
+en:
+  errors:
+    messages:
+      invalid_date: "is not a valid date"
+      invalid_time: "is not a valid time"
+      invalid_datetime: "is not a valid datetime"
+      is_at: "must be at %{restriction}"
+      before: "must be before %{restriction}"
+      on_or_before: "must be on or before %{restriction}"
+      after: "must be after %{restriction}"
+      on_or_after: "must be on or after %{restriction}"
+  validates_timeliness:
+    error_value_formats:
+      date: '%Y-%m-%d'
+      time: '%H:%M:%S'
+      datetime: '%Y-%m-%d %H:%M:%S'

--- a/config/locales/validates_timeliness.ja.yml
+++ b/config/locales/validates_timeliness.ja.yml
@@ -1,0 +1,16 @@
+ja:
+  errors:
+    messages:
+      invalid_date: "は正しい形式で入力してください。"
+      invalid_time: "は正しい形式で入力してください。"
+      invalid_datetime: "は正しい形式で入力してください。"
+      is_at: "は %{restriction} である必要があります。"
+      before: "は %{restriction} より前を指定してください。"
+      on_or_before: "は %{restriction} 以前を指定してください。"
+      after: "は %{restriction} より後を指定してください。"
+      on_or_after: "は %{restriction} 以降を指定してください。"
+  validates_timeliness:
+    error_value_formats:
+      date: '%Y-%m-%d'
+      time: '%H:%M'
+      datetime: '%Y-%m-%d %H:%M'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,26 @@
 Rails.application.routes.draw do
+
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   root 'travel_planning#index'
-  # ここから追記
+
   namespace :api, { format: 'json' } do
     namespace :v1 do
         resources :schedule_each_date
     end
   end
-# 追記終了
+
   resources :travel_planning, only:[:create,:new,:edit,:update,:destroy,:index]
-  resources :travel_planning_date, only:[:index,:create]
+  resources :travel_planning_date, only:[:index]
+  resources :travel_planning_time, only:[:show,:update]
+
+  resources :spot_search, :only => [ :index, :show, :create, :destroy ] do
+    collection do
+      get :list
+    end
+    member do
+      get :select
+    end
+  end
+
 end

--- a/db/migrate/20171120205344_create_schedule_each_times.rb
+++ b/db/migrate/20171120205344_create_schedule_each_times.rb
@@ -1,0 +1,15 @@
+class CreateScheduleEachTimes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :schedule_each_times do |t|
+      t.integer :schedule_id
+      t.integer :schedule_each_date_id
+      t.integer :user_id
+      t.integer :place_id
+      t.string :memo
+      t.time :from_time
+      t.time :to_time
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171123051348_create_spots.rb
+++ b/db/migrate/20171123051348_create_spots.rb
@@ -1,0 +1,12 @@
+class CreateSpots < ActiveRecord::Migration[5.1]
+  def change
+    create_table :spots do |t|
+      t.string :name
+      t.string :address
+      t.float :latitude
+      t.float :longitude
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115205436) do
+ActiveRecord::Schema.define(version: 20171123051348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,12 +54,33 @@ ActiveRecord::Schema.define(version: 20171115205436) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "schedule_each_times", force: :cascade do |t|
+    t.integer "schedule_id"
+    t.integer "schedule_each_date_id"
+    t.integer "user_id"
+    t.integer "place_id"
+    t.string "memo"
+    t.time "from_time"
+    t.time "to_time"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "schedules", force: :cascade do |t|
     t.integer "user_id"
     t.date "from_date"
     t.date "to_date"
     t.string "title"
     t.string "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "spots", force: :cascade do |t|
+    t.string "name"
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
■スケジュールの時間帯別で開始時刻、終了時刻、場所、メモを入力し登録できるようにしました
・一番下の登録ボタンを押すまでは、”スケジュールを追加”をいうリンクでスケジュールを動的に増やすことができます。
・また場所については、別画面でGoogleMapPlaceAPIを用いて、
検索かけたものを表示させます。
また登録後の一覧画面にあるリストの、各データの一番右ボタンを選択することで、ウィンドウを消し、元の画面に場所名を表示させる流れになっています。

※別画面で場所を検索する詳細機能については完成ではないため、次回のissues#5でやるとともに、
今回やる予定だった、地図でルート案内を表示するのも次回issuesに回します。