### PR TITLE
issues#6 spot_detail finish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem 'jc-validates_timeliness'
 
 gem 'jquery-datatables-rails'
 
+gem 'httparty'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -583,6 +583,7 @@ DEPENDENCIES
   google_places
   gretel
   hirb
+  httparty
   jbuilder (~> 2.5)
   jc-validates_timeliness
   jquery-datatables-rails

--- a/app/views/spot_search/list.html.erb
+++ b/app/views/spot_search/list.html.erb
@@ -17,7 +17,8 @@
           <td><%= link_to( '登録', spot_search_index_path( :spot => { :name      => spot.name,
                                                                  :latitude  => spot.lat,
                                                                  :longitude => spot.lng,
-                                                                 :address   => spot.formatted_address, } ),:method => 'post' ) %>
+                                                                 :address   => spot.formatted_address,
+                                                                 :place_id   => spot.place_id} ),:method => 'post' ) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/spot_search/show.html.erb
+++ b/app/views/spot_search/show.html.erb
@@ -1,31 +1,40 @@
-<div class="col-md-12">
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Latitude</th>
-        <th>Longitude</th>
-        <th>Address</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><%= @spot.name %></td>
-        <td><%= @spot.latitude %></td>
-        <td><%= @spot.longitude %></td>
-        <td><%= @spot.address %></td>
-      </tr>
-    </tbody>
-  </table>
+<h1 class="text-center">スポット詳細</h1>
+<u><h3 class="text-center"><%= @spot_details.name %></h3></u>
 
-  <button type="button" class="btn pull-right btn-lg btn-default">
-    <%= link_to '戻る', spot_search_index_path,:onclick => "
-    location.reload();" %>
-  </button>
+<button type="button" class="btn pull-right btn-lg btn-default">
+  <%= link_to '戻る', spot_search_index_path,:onclick => "
+  location.reload();" %>
+</button>
 
-</div>
-<div id="map" style="width: 800px; height: 400px;"></div>
 
+<div id="map" class="center-block" style="width: 800px; height: 400px;"></div>
+
+<% @arr.each do |photo_reference| %>
+  <%= image_tag(url_for(:action => 'getImg', :photo_reference => photo_reference), :size => '100x100')%></td>
+<% end %>
+
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>住所</th>
+      <th>営業時間</th>
+      <th>Tel</th>
+      <th>サイトURL</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><%= @formatted_address %></td>
+      <td>
+        <% if @spot_details.opening_hours != nil %>
+              <%= @spot_details.opening_hours["periods"][0]["open"]["time"].insert(2, ":") %>〜<%= @spot_details.opening_hours["periods"][0]["close"]["time"].insert(2, ":") if @spot_details.opening_hours["periods"][0]["close"] != nil %>
+        <% end %>
+      </td>
+      <td><%= @spot_details.formatted_phone_number %></td>
+      <td><%= link_to @spot_details.website,@spot_details.website, :target=>["_blank"] if @spot_details.website != nil%></td>
+    </tr>
+  </tbody>
+</table>
 <script>
   handler = Gmaps.build('Google');
   handler.buildMap({ provider: {}, internal: {id: 'map'}}, function(){

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   resources :spot_search, :only => [ :index, :show, :create, :destroy ] do
     collection do
       get :list
+      get :getImg
     end
     member do
       get :select

--- a/db/migrate/20171204214032_add_place_id_to_spot.rb
+++ b/db/migrate/20171204214032_add_place_id_to_spot.rb
@@ -1,0 +1,5 @@
+class AddPlaceIdToSpot < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spots, :place_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171126204338) do
+ActiveRecord::Schema.define(version: 20171204214032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 20171126204338) do
     t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "place_id"
   end
 
 end


### PR DESCRIPTION
内藤さん
スポット詳細も完成したので、ご確認お願いします。

基本は、対象スポットの地図表示、各項目をGoogle Place Apiからデータを取ってきて表示させています。

詳細データを取ってくるために、Spotテーブルのカラムでplace_idを追加（※検索時に詳細データを取得できるようにするため）
→なので、今回動作確認する際は、新たにスポットで追加させるか、既存おデータであれば、プレイスIDをリファレンスで検索できるので、調べていただき、直接データを入れていただく必要があります

また土曜日のバイナリの画像のやり方で、複数件画像を表示させることができるようになりました。
最大１０枚まで表示できるようになっています。
