### PR TITLE
issues#7 header create design repair

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,3 +1,7 @@
 #error_explanation {
   color: #ff0000;
 }
+//ヘッダー部分
+.top {
+  margin-top: 50px;
+}

--- a/app/assets/stylesheets/schedule_each_time.scss
+++ b/app/assets/stylesheets/schedule_each_time.scss
@@ -1,9 +1,9 @@
 .nested-fields {
-  margin: 10px 0px;
+  margin: 10px 0;
 }
 #add_fields {
-  margin: 10px 0px;
+  margin: 10px 0;
 }
-#sonota_btns {
-  margin: 0px 30px;
+.sonota_btns {
+  margin: 0 0 10px 30px;
 }

--- a/app/controllers/spot_search_controller.rb
+++ b/app/controllers/spot_search_controller.rb
@@ -5,6 +5,12 @@ class SpotSearchController < ApplicationController
     if params[:user_id].present?
       session[:user_id] = params[:user_id]
     end
+    #時間帯別の場所名を選択するリンクから来た場合は、選択ボタンを表示させるが、
+    #ヘッダーから遷移して来た場合は表示させない
+    if params[:select_link_disp].present?
+      params[:select_link_disp] == "true" ? params[:select_link_disp] = true : params[:select_link_disp] = false
+      session[:select_link_disp] = params[:select_link_disp]
+    end
     @spots = Spot.all
   end
 

--- a/app/controllers/travel_planning_time_controller.rb
+++ b/app/controllers/travel_planning_time_controller.rb
@@ -2,10 +2,8 @@ class TravelPlanningTimeController < ApplicationController
   before_action :set_schedule_date, only: [:show,:edit, :update, :destroy,:show_spot_roting]
   def show
     #対象スケジュール日付に紐づくスケジュール時間帯別が１軒もない場合は、スケジュール時間帯別を新規作成
-    @delete_btn_disp_flg = true
     if @schedule_each_date.schedule_each_times.empty?
       @schedule_each_date.schedule_each_times.new(schedule_id: @schedule_each_date.schedule_id, schedule_each_date_id: @schedule_each_date.id, user_id:@schedule_each_date.user_id)
-      @delete_btn_disp_flg = false
     end
     getSpotAll
   end

--- a/app/controllers/travel_planning_time_controller.rb
+++ b/app/controllers/travel_planning_time_controller.rb
@@ -2,8 +2,10 @@ class TravelPlanningTimeController < ApplicationController
   before_action :set_schedule_date, only: [:show,:edit, :update, :destroy,:show_spot_roting]
   def show
     #対象スケジュール日付に紐づくスケジュール時間帯別が１軒もない場合は、スケジュール時間帯別を新規作成
+    @delete_btn_disp_flg = true
     if @schedule_each_date.schedule_each_times.empty?
       @schedule_each_date.schedule_each_times.new(schedule_id: @schedule_each_date.schedule_id, schedule_each_date_id: @schedule_each_date.id, user_id:@schedule_each_date.user_id)
+      @delete_btn_disp_flg = false
     end
     getSpotAll
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,0 +1,17 @@
+<header class="navbar navbar-fixed-top navbar-inverse">
+   <div class="container">
+     <nav>
+       <ul class="nav navbar-nav navbar-left">
+         <li><%= link_to "旅行計画作成",    travel_planning_index_path %></li>
+       </ul>
+       <ul class="nav navbar-nav navbar-left">
+         <!-- あとでユーザIDの部分を変更 -->
+         <li><%= link_to "スポット検索",    spot_search_index_path(user_id: 1,select_link_disp: false),:onclick => "
+         location.reload();" %></li>
+       </ul>
+     </nav>
+     <ul class="nav navbar-nav navbar-right">
+       <li><%= link_to "Travel Planning", travel_planning_index_path, id: "logo" %></li>
+     </ul>
+   </div>
+ </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,8 @@
   </head>
 
   <body>
-    <div class="container">
+  <%= render 'layouts/header' %>
+    <div class="container top">
       <%= yield %>
     </div>
   </body>

--- a/app/views/spot_search/index.html.erb
+++ b/app/views/spot_search/index.html.erb
@@ -1,6 +1,5 @@
-<h1>スポット検索</h1>
-
 <div class="col-md-6">
+  <h1>スポット検索</h1>
   <%= form_tag list_spot_search_index_path, :role =>"form", :method => :get do %>
     <div class="form-group">
       <%= text_field_tag :search, params[:search], { :class => "form-control", :required => true,  :placeholder => "都市名×スポット名またはキーワードを入力してください" } %>
@@ -19,7 +18,9 @@
         <th>住所</th>
         <th></th>
         <th></th>
+      <% if session[:select_link_disp] == true %>
         <th></th>
+      <% end %>
         <th></th>
       </tr>
     </thead>
@@ -35,9 +36,11 @@
           <td><%= link_to( spot_search_path(spot), method: :delete, data: { confirm: "#{spot.name} の位置情報を削除します" }, :title => "delete" ) do %>
             <span class="glyphicon glyphicon-trash"></span>
           <% end %></td>
-          <td><%= link_to select_spot_search_path(spot) do %>
-            <span class="glyphicon glyphicon-save-file" aria-hidden="true"></span>
-          <% end %></td>
+          <% if session[:select_link_disp] == true %>
+            <td><%= link_to select_spot_search_path(spot) do %>
+              <span class="glyphicon glyphicon-save-file" aria-hidden="true"></span>
+            <% end %></td>
+          <% end %>
           <td><%= link_to favorite_create_spot_search_path(spot) do %>
             <span class="glyphicon glyphicon-star" aria-hidden="true"></span>
           <% end %></td>

--- a/app/views/spot_search/list.html.erb
+++ b/app/views/spot_search/list.html.erb
@@ -1,6 +1,5 @@
-<h1>スポット検索結果</h1>
-
 <div class="col-md-12">
+  <h1>スポット検索結果</h1>
   <table id = "spots" class="table table-striped table-bordered">
     <thead>
       <tr>

--- a/app/views/travel_planning/index.html.erb
+++ b/app/views/travel_planning/index.html.erb
@@ -1,7 +1,4 @@
 <div class="row">
-  <div class="row">
-    <div class="col-md-4 col-md-offset-4 text-center"><h2>旅行一覧</h2></div>
-  </div>
   <aside class="col-md-4">
     <!-- サイドパネル設置予定 -->
   </aside>
@@ -9,14 +6,21 @@
 
     <% flash_messages %>
     <div class="schedule-index pull-left">
+      <div class="row">
+        <div class="col-md-4 col-md-offset-4 text-center"><h2>旅行一覧</h2></div>
+      </div>
       <%= render "index" %>
-      <div class="row col-md-8 col-md-offset-2">
+      <div class="row">
+        <div class="col-md-4 col-md-offset-4 text-center">
           <%= link_to new_travel_planning_path, remote: true, class: "btn btn-default" do  %>
             <i class="glyphicon glyphicon-plus" aria-hidden="true"></i>
           <% end %>
+        </div>
       </div>
-      <div class="row col-md-10 col-md-offset-1">
-        <%= paginate @schedules %>
+      <div class="row">
+        <div class="col-md-10 col-md-offset-1 text-center">
+          <%= paginate @schedules %>
+        </div>
       </div>
     </div>
 

--- a/app/views/travel_planning_date/_index.html.erb
+++ b/app/views/travel_planning_date/_index.html.erb
@@ -1,5 +1,5 @@
 <%= link_to  travel_planning_index_path() do  %>
   <i class="glyphicon glyphicon-backward"> 戻る</i>
 <% end %>
-<div id="calendar"></div>
+<div id="calendar" class="bottom"></div>
 <%= hidden_field_tag :schedule_id, @schedule_id %>

--- a/app/views/travel_planning_date/index.html.erb
+++ b/app/views/travel_planning_date/index.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="row">
-    <div class="col-md-4 col-md-push-6 text-center"><h2>旅行スケジュール日程作成</h2></div>
+    <div class="col-md-4 col-md-push-6 text-center"><h2>スケジュール日程作成</h2></div>
   </div>
   <aside class="col-md-4">
     <!-- サイドパネル設置予定 -->

--- a/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
+++ b/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
@@ -20,7 +20,7 @@
       localStorage.setItem('place_id', place_id);
       window.open(this.href, 'height=800, width=800');return false;"  %>
     </div>
-    <% if @delete_btn_disp_flg == true %>
+    <% if @schedule_each_date.schedule_each_times.count != 0 %>
       <%= link_to_remove_association "このスケジュールを削除する", f %>
     <% end %>
 </div>

--- a/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
+++ b/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
@@ -14,11 +14,13 @@
       <%= f.label :place_id, "場所" %>
       <%= f.select :place_id, @spots, {}, :disabled => true %>
       <%= f.hidden_field :place_id %>
-      <%= link_to '場所名を選択する', spot_search_index_path(user_id: @schedule_each_date.user_id), :onclick => "
+      <%= link_to '場所名を選択する', spot_search_index_path(user_id: @schedule_each_date.user_id,select_link_disp: true), :onclick => "
       var prevElement1 = event.target.previousElementSibling;
       var place_id = prevElement1.getAttribute('name');
       localStorage.setItem('place_id', place_id);
       window.open(this.href, 'height=800, width=800');return false;"  %>
     </div>
-    <%= link_to_remove_association "このスケジュールを削除する", f %>
+    <% if @delete_btn_disp_flg == true %>
+      <%= link_to_remove_association "このスケジュールを削除する", f %>
+    <% end %>
 </div>

--- a/app/views/travel_planning_time/show.html.erb
+++ b/app/views/travel_planning_time/show.html.erb
@@ -1,7 +1,4 @@
 <div class="row">
-  <div class="row">
-    <div class="col-md-4 col-md-push-6 text-center"><h2>旅行スケジュール時間帯別作成</h2></div>
-  </div>
   <aside class="col-md-4">
     <!-- サイドパネル設置予定 -->
   </aside>
@@ -17,6 +14,9 @@
         </ul>
       </div>
     <% end %>
+    <div class="row">
+      <div class="col-md-4 col-md-push-4 text-center"><h4>スケジュール時間帯別作成</h4></div>
+    </div>
     <% i = 1 %>
     <%= form_for @schedule_each_date, :url => {:controller => :travel_planning_time, :action => :update} do |f| %>
       <div class="field">
@@ -34,18 +34,20 @@
           </strong>
           <% end %>
         </ol>
-        <div class="actions">
+        <div class="sonota_btns">
           <%= f.submit "登録する" %>
         </div>
       </div>
     <% end %>
-    <strong class="sonota_btns">
-      <%= link_to 'ルートを地図で確認する', show_spot_roting_travel_planning_time_index_path(id: @schedule_each_date.id) %>
-    </strong>
-    <strong class="sonota_btns">
-      <%= link_to  travel_planning_date_index_path(:schedule_id => @schedule_each_date.schedule_id) do  %>
-        <i class="glyphicon glyphicon-step-backward" aria-hidden="true">(戻る)</i>
-      <% end %>
-    </strong>
+    <% if @schedule_each_date.schedule_each_times.count >= 2 %>
+      <strong class="sonota_btns">
+        <%= link_to 'ルートを地図で確認する', show_spot_roting_travel_planning_time_index_path(id: @schedule_each_date.id) %>
+      </strong>
+    <% end %>
+      <strong class="sonota_btns">
+        <%= link_to  travel_planning_date_index_path(:schedule_id => @schedule_each_date.schedule_id) do  %>
+          <i class="glyphicon glyphicon-step-backward" aria-hidden="true">(戻る)</i>
+        <% end %>
+      </strong>
   </div>
 </div>


### PR DESCRIPTION
・ヘッダーを追加しました。（旅行作成、スポット検索のみ）
※今後ユーザ設定やログインログアウト、通知のヘッダーは機能作成時に同時に盛り込みます。

・その他、今まで作成した機能でレイアウトの気になる点は修正

・スケジュール時間帯別作成画面で、１件目の新規作成時に削除するボタンは表示させないように修正
→削除ボタンで削除して、登録させようとするとエラーとなるため

・また同じくスケジュール時間帯別作成画面で、地図のルート確認の地図リンクを表示させるのは、２件目以降にするよう処理を追加

・スポット検索では、スケジュール時間帯別で”場所名を選択する”のリンクからスポットを選択し場所名を表示させるための、スポット検索画面にある選択ボタン（スポット一覧に表示されているボタンの右から二番目）を、ヘッダーからスポット一覧に遷移させた時は非表示にするよう処理を追加。
