### PR TITLE
issues#8 user acoount create user use function repair

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   add_flash_types :success, :info, :warning, :danger
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def after_sign_in_path_for(resource)
+      travel_planning_index_path
+  end
+
+  protected
+    def sign_in_required
+        redirect_to new_user_session_url unless user_signed_in?
+    end
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+      devise_parameter_sanitizer.permit(:account_update, keys: [:username])
+    end
+
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,7 @@
+class HomeController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,34 @@
+class RegistrationsController < Devise::RegistrationsController
+  def create
+    build_resource(sign_up_params)
+
+    resource.save
+    yield resource if block_given?
+    if resource.persisted?
+      if resource.active_for_authentication?
+        #メール送信部分を追加した以外は、元々のdeviceのcreateと同じ
+        UserMailer.send_signup_email(resource,root_url).deliver
+        UserMailer.send_signup_admin_email(resource,root_url).deliver
+        set_flash_message! :notice, :signed_up
+        sign_up(resource_name, resource)
+        respond_with resource, location: after_sign_up_path_for(resource)
+      else
+        set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+        expire_data_after_sign_in!
+        respond_with resource, location: after_inactive_sign_up_path_for(resource)
+      end
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      respond_with resource
+    end
+  end
+
+  protected
+  def update_resource(resource, params)
+    resource.update_without_current_password(params)
+  end
+  def after_update_path_for(resource)
+   edit_user_registration_path(resource)
+  end
+end

--- a/app/controllers/travel_planning_controller.rb
+++ b/app/controllers/travel_planning_controller.rb
@@ -5,7 +5,7 @@ class TravelPlanningController < ApplicationController
   PER = 10
 
   def index
-    @schedules = Schedule.page(params[:page]).per(PER).order('created_at')
+    @schedules = Schedule.where(user_id: current_user.id).page(params[:page]).per(PER).order('created_at')
   end
 
   def new
@@ -28,7 +28,7 @@ class TravelPlanningController < ApplicationController
         sche_err_chk
       end
     end
-    redirect_to root_path
+    redirect_to travel_planning_index_path
   end
 
   def edit
@@ -48,7 +48,7 @@ class TravelPlanningController < ApplicationController
         sche_err_chk
       end
     end
-    redirect_to root_path
+    redirect_to travel_planning_index_path
   end
 
   def destroy
@@ -62,7 +62,7 @@ class TravelPlanningController < ApplicationController
         flash[:error] = "スケジュールの削除に失敗しました"
       end
     end
-    redirect_to root_path
+    redirect_to travel_planning_index_path
   end
 
   private
@@ -89,10 +89,10 @@ class TravelPlanningController < ApplicationController
 
      #初日からループで回し、１件ごとにデータ作成
      for i in 1..travel_term
-       if !@schedule.schedule_each_dates.create!( user_id: 1, schedule_id: @schedule.id ,sche_date: start_date)
+       if !@schedule.schedule_each_dates.create!( user_id: current_user.id, schedule_id: @schedule.id ,sche_date: start_date)
          #失敗すれば、エラーメッセージ
            flash[:error] = "スケジュールの作成または更新に失敗しました"
-           redirect_to root_path
+           redirect_to travel_planning_index_path
        end
        start_date = start_date + 1
      end
@@ -101,7 +101,7 @@ class TravelPlanningController < ApplicationController
   def set_schedule
     @schedule = Schedule.find(params[:id])
   end
-  
+
   def schedule_params
     params.require(:schedule).permit(:user_id,:from_date,:to_date,:title)
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,20 @@
+class UserMailer < ApplicationMailer
+  default :from => ENV['GMAIL_ADRESS']
+
+  def send_signup_email(user,root_url)
+    @user = user
+    @root_url = root_url
+    mail( :to => @user.email,
+    :subject => '登録完了' )
+  end
+  def send_signup_admin_email(user,root_url)
+    @user = user
+    @root_url = root_url + 'admin/'
+    @admin_user = AdminUser.all
+    @admin_user.each do |admin_user|
+      mail( :to => admin_user.email,
+      :subject => '新規ユーザ追加' )
+    end
+  end
+
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,6 +1,7 @@
 require 'date'
 class Schedule < ApplicationRecord
-  has_many :schedule_each_dates
+  belongs_to :user
+  has_many :schedule_each_dates,dependent: :destroy
   validates :title, presence: true,length: { maximum: 100 }
   validates :from_date, presence: true, date: true
   validates :to_date, presence: true, date: true

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,2 +1,3 @@
 class Spot < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,28 @@
+class User < ApplicationRecord
+  # Include default devise modules. Others available are:
+  # :confirmable, :lockable, :timeoutable and :omniauthable
+  devise :database_authenticatable, :registerable,
+         :recoverable, :rememberable, :trackable, :validatable
+  has_many :schedules,dependent: :destroy
+  has_many :spots,dependent: :delete_all
+
+  validates :username, presence: true
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, format: { with: VALID_EMAIL_REGEX }
+
+ #ユーザアカウント更新時にパスワードとパスワード確認が空なら、パスワード部分は無視して更新
+  def update_without_current_password(params, *options)
+
+    params.delete(:current_password)
+
+    if params[:password].blank? && params[:password_confirmation].blank?
+      params.delete(:password)
+      params.delete(:password_confirmation)
+    end
+
+    result = update_attributes(params, *options)
+    clean_up_passwords
+    result
+  end
+
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,10 +2,16 @@
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= devise_error_messages! %>
+  <% flash_messages %>
+
+  <div class="field">
+   <%= f.label :username %><br />
+   <%= f.text_field :username, autofocus: true %>
+  </div>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= f.email_field :email %>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
@@ -26,18 +32,11 @@
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
   </div>
 
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "off" %>
-  </div>
-
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit "更新" %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<p><%= button_to "アカウント削除", registration_path(resource_name), data: { confirm: "ユーザアカウントを削除してもよろしいでしょうか?" }, method: :delete %></p>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<%= link_to "戻る", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,11 +1,16 @@
-<h2>Sign up</h2>
+<h2>アカウント新規作成</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
   <%= devise_error_messages! %>
 
   <div class="field">
+   <%= f.label :username %><br />
+   <%= f.text_field :username, autofocus: true %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true %>
+    <%= f.email_field :email %>
   </div>
 
   <div class="field">
@@ -22,8 +27,6 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit "アカウント作成" %>
   </div>
 <% end %>
-
-<%= render "devise/shared/links" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Home#index</h1>
+<p>Find me in app/views/home/index.html.erb</p>

--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -1,0 +1,2 @@
+<h1>Home#show</h1>
+<p>Find me in app/views/home/show.html.erb</p>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,8 +6,14 @@
        </ul>
        <ul class="nav navbar-nav navbar-left">
          <!-- あとでユーザIDの部分を変更 -->
-         <li><%= link_to "スポット検索",    spot_search_index_path(user_id: 1,select_link_disp: false),:onclick => "
+         <li><%= link_to "スポット検索",    spot_search_index_path(select_link_disp: false),:onclick => "
          location.reload();" %></li>
+       </ul>
+       <ul class="nav navbar-nav navbar-left">
+         <li><%= link_to 'プロフィール変更', edit_user_registration_path %></li>
+       </ul>
+       <ul class="nav navbar-nav navbar-left">
+         <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
        </ul>
      </nav>
      <ul class="nav navbar-nav navbar-right">

--- a/app/views/layouts/_login_ago_header.html.erb
+++ b/app/views/layouts/_login_ago_header.html.erb
@@ -1,0 +1,27 @@
+<header class="navbar navbar-fixed-top navbar-inverse">
+   <div class="container">
+     <div class="row">
+       <div class="col-md-3">
+         <nav>
+           <ul class="nav navbar-nav navbar-left">
+             <li><%= link_to "ホーム",    root_path %></li>
+           </ul>
+         </nav>
+       </div>
+       <div class="col-md-6">
+         <ul class="nav  navbar-nav_center">
+           <li><%= link_to "Travel Planning", '#', id: "logo_ago" %></li>
+         </ul>
+       </div>
+       <div class="col-md-3">
+         <ul class="nav navbar-nav navbar-right">
+           <li><%= link_to "アカウント作成",    new_user_registration_path
+           %></li>
+           <li><%= link_to "ログイン", new_user_session_path
+            %></li>
+         </ul>
+       </div>
+     </div>
+
+   </div>
+ </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,11 @@
   </head>
 
   <body>
-  <%= render 'layouts/header' %>
+  <% if user_signed_in? %>
+    <%= render 'layouts/header' %>
+  <% else %>
+    <%= render 'layouts/login_ago_header' %>
+  <% end %>
     <div class="container top">
       <%= yield %>
     </div>

--- a/app/views/spot_search/list.html.erb
+++ b/app/views/spot_search/list.html.erb
@@ -17,7 +17,9 @@
                                                                  :latitude  => spot.lat,
                                                                  :longitude => spot.lng,
                                                                  :address   => spot.formatted_address,
-                                                                 :place_id   => spot.place_id} ),:method => 'post' ) %>
+                                                                 :place_id   => spot.place_id,
+                                                                 :user_id   => current_user.id,
+                                                                 :favorite_flg   => false} ),:method => 'post' ) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/travel_planning/_index.html.erb
+++ b/app/views/travel_planning/_index.html.erb
@@ -1,3 +1,4 @@
+<% if @schedules.count != 0%>
 <table class="table table-striped table-hover">
 <% @schedules.each do |schedule| %>
   <tr>
@@ -22,3 +23,6 @@
   </tr>
 <% end %>
 </table>
+<% else %>
+<div class="well">データが１件もありません。下記のボタンでスケジュール登録を行ってください</div>
+<% end %>

--- a/app/views/travel_planning/_sche_modal_form.html.erb
+++ b/app/views/travel_planning/_sche_modal_form.html.erb
@@ -19,6 +19,6 @@
 <div class="modal-footer">
   <button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
   <!-- ユーザテーブル作成後編集し確認 -->
-  <%= f.hidden_field :user_id, :value =>  '1' %>
+  <%= f.hidden_field :user_id, :value =>  current_user.id %>
   <%= f.primary modal_kbn %>
 </div>

--- a/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
+++ b/app/views/travel_planning_time/_schedule_each_time_fields.html.erb
@@ -14,7 +14,7 @@
       <%= f.label :place_id, "場所" %>
       <%= f.select :place_id, @spots, {}, :disabled => true %>
       <%= f.hidden_field :place_id %>
-      <%= link_to '場所名を選択する', spot_search_index_path(user_id: @schedule_each_date.user_id,select_link_disp: true), :onclick => "
+      <%= link_to '場所名を選択する', spot_search_index_path(select_link_disp: true), :onclick => "
       var prevElement1 = event.target.previousElementSibling;
       var place_id = prevElement1.getAttribute('name');
       localStorage.setItem('place_id', place_id);

--- a/app/views/user_mailer/send_signup_admin_email.erb
+++ b/app/views/user_mailer/send_signup_admin_email.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1> <%= @user.username %>様のデータが登録されました</h1>
+    <p>詳細は管理画面で確認してください</p>
+    <%= link_to "管理画面へ",@root_url %>
+  </body>
+</html>

--- a/app/views/user_mailer/send_signup_email.erb
+++ b/app/views/user_mailer/send_signup_email.erb
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1> <%= @user.username %>様,登録ありがとうございます</h1>
+    <p>あなたの旅行計画作成に少しでもお役に立てるよう、ぜひご利用ください</p>
+    <%= link_to "Travel Planning",@root_url %>
+  </body>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,8 +28,17 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
-
-  config.action_mailer.default_url_options = { host: 'localhost:3000' } 
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  #config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :user_name => ENV['GMAIL_ADRESS'],
+    :password => ENV['GMAIL_PASSWORD'],
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
 
   config.action_mailer.perform_caching = false
 

--- a/config/locales/device.ja.yml
+++ b/config/locales/device.ja.yml
@@ -1,0 +1,98 @@
+ja:
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+#      confirmed: 'Your account was successfully confirmed. You are now signed in.'
+      send_instructions: '登録方法を数分以内にメールでご連絡します。'
+#      send_instructions: 'You will receive an email with instructions about how to confirm your account in a few minutes.'
+      send_paranoid_instructions: 'もしあなたのEメールアドレスが見つかった場合、本人確認についてのメールが数分以内に送られます。'
+#      send_paranoid_instructions: 'If your email address exists in our database, you will receive an email with instructions about how to confirm your account in a few minutes.'
+    failure:
+      already_authenticated: '既にログインしています。'
+#      already_authenticated: 'You are already signed in.'
+      inactive: 'アカウントがアクティベートされていません。'
+#      inactive: 'Your account was not activated yet.'
+      invalid: 'メールアドレスかパスワードが違います。'
+#      invalid: 'Invalid email or password.'
+      invalid_token: '認証キーが不正です。'
+#      invalid_token: 'Invalid authentication token.'
+      locked: 'あなたのアカウントは凍結されています。'
+#      locked: 'Your account is locked.'
+      not_found_in_database: 'メールアドレスかパスワードが違います。'
+#      not_found_in_database: "Invalid email or password."
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+#      timeout: 'Your session expired, please sign in again to continue.'
+      unauthenticated: 'ログインしてください。'
+#      unauthenticated: 'You need to sign in or sign up before continuing.'
+      unconfirmed: '本登録を行ってください。'
+#      unconfirmed: 'You have to confirm your account before continuing.'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの登録方法'
+#        subject: 'Confirmation instructions'
+      reset_password_instructions:
+        subject: 'パスワードの再設定'
+#        subject: 'Reset password instructions'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除'
+#        subject: 'Unlock Instructions'
+    omniauth_callbacks:
+      success: '%{kind} アカウントによる個人認証に成功しました。'
+#      success: 'Successfully authenticated from %{kind} account.'
+      failure: '%{kind} アカウントによる個人認証に失敗しました（%{reason}）。'
+#      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード復元メールのリンクをコピーした場合には、正しい URL かどうかをお確かめください。"
+#      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: 'パスワードのリセット方法を数分以内にメールでご連絡します。'
+#      send_instructions: 'You will receive an email with instructions about how to reset your password in a few minutes.'
+      send_paranoid_instructions: "もしあなたのEメールアドレスが見つかった場合、パスワード復元用のメールが数分以内に送られます。"
+#      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: 'パスワードを変更しました。'
+#      updated: 'Your password was changed successfully. You are now signed in.'
+      updated_not_active: 'パスワードが正しく変更されました。'
+#      updated_not_active: 'Your password was changed successfully.'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+#      destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
+      signed_up: 'ようこそ！ アカウント登録を受け付けました。'
+#      signed_up: 'Welcome! You have signed up successfully.'
+      signed_up_but_inactive: 'アカウント登録を受け付けました。しかしまだ有効化されておらず、ログインできません。'
+#      signed_up_but_inactive: 'You have signed up successfully. However, we could not sign you in because your account is not yet activated.'
+      signed_up_but_locked: 'アカウント登録を受け付けました。しかし、アカウントが凍結されているためログインできません。'
+#      signed_up_but_locked: 'You have signed up successfully. However, we could not sign you in because your account is locked.'
+      signed_up_but_unconfirmed: '本人確認用のメールがあなたのEメールアドレスに送られました。メール内のリンクからアカウントを有効化させてください。'
+#      signed_up_but_unconfirmed: 'A message with a confirmation link has been sent to your email address. Please open the link to activate your account.'
+      updated: 'アカウント情報を変更しました。'
+#      updated: 'You updated your account successfully.'
+      update_needs_confirmation: "アカウント情報を変更しましたが、Eメールアドレスの本人確認用Eメールをお送りしましたので、中のリンクをクリックして証明してください。"
+#      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and click on the confirm link to finalize confirming your new email address."
+    sessions:
+      signed_in: 'ログインしました。'
+#      signed_in: 'Signed in successfully.'
+      signed_out: 'ログアウトしました。'
+#      signed_out: 'Signed out successfully.'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+#      send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+#      send_paranoid_instructions: 'If your account exists, you will receive an email with instructions about how to unlock it in a few minutes.'
+      unlocked: 'アカウントを凍結解除しました。ログインしています。'
+#      unlocked: 'Your account was successfully unlocked. You are now signed in.'
+  errors:
+    messages:
+      already_confirmed: "は既に登録済みですのでログインしてください"
+#      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "の確認期限が切れました。%{period}以内に確認する必要があります。 新しくリクエストしてください"
+#      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "の期限が切れましたので、新しくリクエストしてください"
+#      expired: "has expired, please request a new one"
+      not_found: "は見つかりませんでした"
+#      not_found: "not found"
+      not_locked: "は凍結されていません"
+#      not_locked: "was not locked"
+      not_saved:
+        one: "1 つのエラーにより %{resource} は登録されませんでした"
+#        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} つのエラーにより %{resource} は登録されませんでした"
+#        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
       name: 名前
       schedule_each_date: スケジュール日付別
       schedule_each_time: スケジュール時間帯別
+      user: ユーザ
     attributes:
       admin_user:
         email: メールアドレス
@@ -23,6 +24,8 @@ ja:
         date: 日付
         created_at: 作成日時
         updated_at: 更新日時
+      user:
+        username: 名前
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
 
+  devise_for :users, controllers: { registrations: 'registrations' }
+  get 'home/index'
+
+  get 'home/show'
+
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
-  root 'travel_planning#index'
-
+  root to: "home#index"
   namespace :api, { format: 'json' } do
     namespace :v1 do
         resources :schedule_each_date

--- a/db/migrate/20171213213203_devise_create_users.rb
+++ b/db/migrate/20171213213203_devise_create_users.rb
@@ -1,0 +1,42 @@
+class DeviseCreateUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :users do |t|
+      ## Database authenticatable
+      t.string :email,              null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+
+      ## Recoverable
+      t.string   :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Rememberable
+      t.datetime :remember_created_at
+
+      ## Trackable
+      t.integer  :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet     :current_sign_in_ip
+      t.inet     :last_sign_in_ip
+
+      ## Confirmable
+      # t.string   :confirmation_token
+      # t.datetime :confirmed_at
+      # t.datetime :confirmation_sent_at
+      # t.string   :unconfirmed_email # Only if using reconfirmable
+
+      ## Lockable
+      # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts
+      # t.string   :unlock_token # Only if unlock strategy is :email or :both
+      # t.datetime :locked_at
+
+
+      t.timestamps null: false
+    end
+
+    add_index :users, :email,                unique: true
+    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :confirmation_token,   unique: true
+    # add_index :users, :unlock_token,         unique: true
+  end
+end

--- a/db/migrate/20171213214407_add_columns_to_users.rb
+++ b/db/migrate/20171213214407_add_columns_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnsToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :username, :string
+  end
+end

--- a/db/migrate/20171216015535_add_user_id_to_spots.rb
+++ b/db/migrate/20171216015535_add_user_id_to_spots.rb
@@ -1,0 +1,5 @@
+class AddUserIdToSpots < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spots, :user_id, :integer
+  end
+end

--- a/db/migrate/20171216033020_add_favorite_flg_to_spots.rb
+++ b/db/migrate/20171216033020_add_favorite_flg_to_spots.rb
@@ -1,0 +1,5 @@
+class AddFavoriteFlgToSpots < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spots, :favorite_flg, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171204214032) do
+ActiveRecord::Schema.define(version: 20171216033020) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,26 @@ ActiveRecord::Schema.define(version: 20171204214032) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "place_id"
+    t.integer "user_id"
+    t.boolean "favorite_flg"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "username"
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
 end


### PR DESCRIPTION
内藤さん
ユーザアカウント設定の実装が終わりましたので、ご確認お願いします。
主に以下３点の修正を行いました。

⑴ユーザアカウント新規追加、変更、削除
新規追加時は対象ユーザと管理者(admin_userテーブルに存在する管理者)にメールを送信
変更時は、パスワード入力なしでも更新可能とした

⑵ユーザID使用部分をcurent_userのIDに変更
ヘッダー、旅行登録時、スポット登録時
※一番最初の旅行一覧やスポット一覧の表示は対象ユーザのみのデータを表示に変更
→別の人が検索した旅行計画やスポットの履歴が見れるのはまずいと思ったので変更
→それに伴い、お気に入りスポット登録テーブル(favorite_spot)の使用をやめ、spotテーブルでお気に入りフラグで管理する方針に変更

⑶Modelでユーザテーブルにひもづくスケジュール関連テーブルやスポットテーブルの削除時のひも付き部分を追加

