### PR TITLE
issues#10 favorite_spot and home create

### DIFF
--- a/app/admin/spots.rb
+++ b/app/admin/spots.rb
@@ -1,0 +1,27 @@
+ActiveAdmin.register Spot do
+# See permitted parameters documentation:
+# https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+#
+# permit_params :list, :of, :attributes, :on, :model
+#
+# or
+#
+# permit_params do
+#   permitted = [:permitted, :attributes]
+#   permitted << :other if params[:action] == 'create' && current_user.admin?
+#   permitted
+# end
+permit_params :name, :address, :place_id, :favorite_flg
+form do |f|
+    inputs  do
+      input :name
+      input :address
+      input :name
+      input :place_id
+      input :favorite_flg
+    end
+
+    actions
+  end
+
+end

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,3 +24,4 @@
 @import "common";
 @import "schedule_each_time";
 @import "login";
+@import "home";

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,0 +1,37 @@
+.carousel{
+  height: 200px;
+  margin:auto;
+}
+.carousel .item {
+  height: 100%;
+}
+
+.carousel img {
+  position: absolute;
+  width: 100%;
+}
+@media (min-width: 320px) {
+  .carousel,
+  .carousel .item,
+  .carousel .item-mask,
+  .carousel-inner .item .item-mask img {
+    height:200px;
+  }
+}
+
+@media (min-width: 768px) {
+  .carousel,
+  .carousel .item,
+  .carousel .item-mask,
+  .carousel-inner .item .item-mask img {
+    height:400px;
+  }
+}
+@media (min-width: 1200px) {
+  .carousel,
+  .carousel .item,
+  .carousel .item-mask,
+  .carousel-inner .item .item-mask img {
+    height:600px;
+  }
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,41 @@
 class HomeController < ApplicationController
   def index
+    #スポットで最新のデータを３件取得
+    @newest_spots = Spot.select(:name,:place_id).order("created_at desc").limit(3).uniq
+
+    @client = GooglePlaces::Client.new( ENV['GOOGLE_MAP_API_KEY'] )
+    @newest_spots_ary = []
+    @newest_spots_hash = {}
+    i = 0
+    #GooglePlaceからデータを取得し、表示用の配列に格納
+    @newest_spots.each do |newest_spot|
+      @spot_details = @client.spot( newest_spot.place_id , :language => 'ja' )
+      @newest_spots_hash.store("name"+i.to_s,@spot_details.name)
+      @newest_spots_hash.store("photo"+i.to_s,@spot_details.photos[0] == nil ? "" : @spot_details.photos[0].photo_reference)
+      @newest_spots_ary.push(@newest_spots_hash)
+      i = i+1
+    end
+
+    #スポットでお気に入りに登録されたのデータを３件取得
+    @favorite_spots = Spot.select(:name,:place_id).where("favorite_flg = ?", true).order("RANDOM()").limit(3).uniq
+    @favorite_spots_ary = []
+
+    @favorite_spots_hash = {}
+    i = 0
+    #GooglePlaceからデータを取得し、表示用の配列に格納
+    @favorite_spots.each do |favorite_spot|
+      @fspot_details = @client.spot( favorite_spot.place_id , :language => 'ja' )
+      @favorite_spots_hash.store("name"+i.to_s,@fspot_details.name)
+      @favorite_spots_hash.store("photo"+i.to_s,@fspot_details.photos[0] == nil ? "" : @fspot_details.photos[0].photo_reference)
+      @favorite_spots_ary.push(@favorite_spots_hash)
+      i = i+1
+    end
+  end
+  def getImg
+    #画像のバイナリデータを取得
+    @photo = HTTParty.get("https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&maxheight=400&photoreference=#{params[:photo_reference]}&key=#{ENV['GOOGLE_MAP_API_KEY']}")
+    #画像データを送信
+    send_data @photo, :type => 'image/png', :disposition => 'inline'
   end
 
-  def show
-  end
 end

--- a/app/controllers/spot_search_controller.rb
+++ b/app/controllers/spot_search_controller.rb
@@ -1,5 +1,6 @@
 class SpotSearchController < ApplicationController
   before_action :set_spot, only: [:show, :destroy, :select,:favorite_create]
+  PAGEING_NUM = 2
   def index
     #時間帯別の場所名を選択するリンクから来た場合は、選択ボタンを表示させるが、
     #ヘッダーから遷移して来た場合は表示させない
@@ -13,13 +14,13 @@ class SpotSearchController < ApplicationController
   def list
     #キーワード検索を行う
     keyword = params[:search]
-    @client = GooglePlaces::Client.new( ENV['GOOGLE_API_KEY'] )
+    @client = GooglePlaces::Client.new( ENV['GOOGLE_MAP_API_KEY'] )
     @spots = @client.spots_by_query( keyword , :language => 'ja' )
 
   end
 
   def show
-    @client = GooglePlaces::Client.new( ENV['GOOGLE_API_KEY'] )
+    @client = GooglePlaces::Client.new( ENV['GOOGLE_MAP_API_KEY'] )
     @spot_details = @client.spot( @spot.place_id , :language => 'ja' )
     #スポットの住所で”国名、”より前が不要なので取り除いた住所を取得
     /、/ =~ @spot_details.formatted_address
@@ -47,9 +48,29 @@ class SpotSearchController < ApplicationController
     end
   end
 
+def favorite_spot_list
+  @client = GooglePlaces::Client.new( ENV['GOOGLE_MAP_API_KEY'] )
+  #スポットで対象ユーザでお気に入りに登録されたのデータを取得
+  @favorite_spots = Spot.select(:name,:place_id).where("favorite_flg = ? and user_id = ?", true, current_user.id).order("created_at").uniq
+  favorite_spots_ary = []
+  @photos_ary = []
+  favorite_spots_hash = {}
+  i = 1
+  #GooglePlaceからデータを取得し、表示用の配列に格納
+  @favorite_spots.each do |favorite_spot|
+    @fspot_details = @client.spot( favorite_spot.place_id , :language => 'ja' )
+    favorite_spots_hash.store("name"+i.to_s,@fspot_details.name)
+    favorite_spots_hash.store("address"+i.to_s,@fspot_details.formatted_address)
+    favorite_spots_hash.store("photo"+i.to_s,@fspot_details.photos[0] == nil ? "" : @fspot_details.photos[0].photo_reference)
+    favorite_spots_ary.push(favorite_spots_hash)
+    i = i+1
+  end
+  @favorite_spots_ary = Kaminari.paginate_array(favorite_spots_ary).page(params[:page]).per(PAGEING_NUM)
+  @pageing_num = PAGEING_NUM
+end
   def getImg
     #画像のバイナリデータを取得
-    @photo = HTTParty.get("https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&maxheight=400&photoreference=#{params[:photo_reference]}&key=#{ENV['GOOGLE_API_KEY']}")
+    @photo = HTTParty.get("https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&maxheight=400&photoreference=#{params[:photo_reference]}&key=#{ENV['GOOGLE_MAP_API_KEY']}")
     #画像データを送信
     send_data @photo, :type => 'image/png', :disposition => 'inline'
   end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,104 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<div class="jumbotron">
+  <h2>Travel Planning</h2>
+  <p>あなたの旅行計画を楽しいものに</p>
+</div>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4>最近登録されたスポット</h4>
+  </div>
+  <div class="panel-body">
+    <% if @newest_spots_ary.count != 0%>
+    <div id="newspot-carousel" class="carousel slide" data-ride="carousel" >
+      <!-- 何枚目かの画像かを表すインディケーター -->
+      <ol class="carousel-indicators">
+        <li data-target="#newspot-carousel" data-slide-to="0" class="active"></li>
+        <li data-target="#newspot-carousel" data-slide-to="1" class=""></li>
+        <li data-target="#newspot-carousel" data-slide-to="2" class=""></li>
+      </ol>
+
+      <% i = 0 %>
+      <!-- 実際の画像の表示処理 -->
+      <div class="carousel-inner">
+        <% @newest_spots_ary.each do |newest_spot| %>
+          <% if i == 0 %>
+            <div class="item active">
+          <% else %>
+            <div class="item">
+          <% end %>
+          <% if newest_spot['photo'+i.to_s] == ""%>
+          <%= image_tag("http://placehold.jp/24/cccccc/ffffff/250x50.png?text=画像が存在しません") %>
+          <% else %>
+            <%= image_tag(url_for(:action => 'getImg', :photo_reference => newest_spot['photo'+i.to_s]),:class => 'center-block')%>
+          <% end %>
+          <div class="carousel-caption"><%= newest_spot['name'+i.to_s] %></div>
+        </div>
+        <% i = i + 1 %>
+        <% end %>
+      </div>
+
+      <!-- 前の画像へ戻るための矢印ポインタ -->
+      <a class="left carousel-control" href="#newspot-carousel" data-slide="prev">
+        <span class="glyphicon glyphicon-chevron-left"></span>
+      </a>
+
+      <!-- 次の画像へ進むための矢印ポインタ -->
+      <a class="right carousel-control" href="#newspot-carousel" data-slide="next">
+        <span class="glyphicon glyphicon-chevron-right"></span>
+      </a>
+    </div>
+    <% else %>
+      <p><データが１件も登録されていません/p>
+    <% end %>
+  </div>
+</div>
+
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4>みんなのお気に入りスポット</h4>
+  </div>
+  <div class="panel-body">
+    <% if @favorite_spots_ary.count != 0 %>
+    <div id="favorite_spot-carousel" class="carousel slide" data-ride="carousel" >
+
+      <!-- 何枚目かの画像かを表すインディケーター -->
+      <ol class="carousel-indicators">
+        <li data-target="#favorite_spot-carousel" data-slide-to="0" class="active"></li>
+        <li data-target="#favorite_spot-carousel" data-slide-to="1" class=""></li>
+        <li data-target="#favorite_spot-carousel" data-slide-to="2" class=""></li>
+      </ol>
+
+      <% i = 0 %>
+      <!-- 実際の画像の表示処理 -->
+      <div class="carousel-inner">
+        <% @favorite_spots_ary.each do |favorite_spot| %>
+          <% if i == 0 %>
+            <div class="item active">
+          <% else %>
+            <div class="item">
+          <% end %>
+          <% if favorite_spot['photo'+i.to_s] == ""%>
+          <%= image_tag("http://placehold.jp/24/cccccc/ffffff/250x50.png?text=画像が存在しません") %>
+          <% else %>
+            <%= image_tag(url_for(:action => 'getImg', :photo_reference => favorite_spot['photo'+i.to_s]),:class => 'center-block')%>
+          <% end %>
+          <div class="carousel-caption"><%= favorite_spot['name'+i.to_s] %></div>
+        </div>
+        <% i = i + 1 %>
+        <% end %>
+      </div>
+      <!-- 前の画像へ戻るための矢印ポインタ -->
+      <a class="left carousel-control" href="#favorite_spot-carousel" data-slide="prev">
+        <span class="glyphicon glyphicon-chevron-left"></span>
+      </a>
+
+      <!-- 次の画像へ進むための矢印ポインタ -->
+      <a class="right carousel-control" href="#favorite_spot-carousel" data-slide="next">
+        <span class="glyphicon glyphicon-chevron-right"></span>
+      </a>
+    </div>
+    <% else %>
+      <p>データが１件もありません</p>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -16,10 +16,9 @@
         <li data-target="#newspot-carousel" data-slide-to="2" class=""></li>
       </ol>
 
-      <% i = 0 %>
       <!-- 実際の画像の表示処理 -->
       <div class="carousel-inner">
-        <% @newest_spots_ary.each do |newest_spot| %>
+        <% @newest_spots_ary.each_with_index do |newest_spot,i| %>
           <% if i == 0 %>
             <div class="item active">
           <% else %>
@@ -28,11 +27,10 @@
           <% if newest_spot['photo'+i.to_s] == ""%>
           <%= image_tag("http://placehold.jp/24/cccccc/ffffff/250x50.png?text=画像が存在しません") %>
           <% else %>
-            <%= image_tag(url_for(:action => 'getImg', :photo_reference => newest_spot['photo'+i.to_s]),:class => 'center-block')%>
+            <%= image_tag(url_for(:action => 'SpotImg', :photo_reference => newest_spot['photo'+i.to_s]),:class => 'center-block')%>
           <% end %>
           <div class="carousel-caption"><%= newest_spot['name'+i.to_s] %></div>
         </div>
-        <% i = i + 1 %>
         <% end %>
       </div>
 
@@ -67,10 +65,9 @@
         <li data-target="#favorite_spot-carousel" data-slide-to="2" class=""></li>
       </ol>
 
-      <% i = 0 %>
       <!-- 実際の画像の表示処理 -->
       <div class="carousel-inner">
-        <% @favorite_spots_ary.each do |favorite_spot| %>
+        <% @favorite_spots_ary.each_with_index do |favorite_spot,i| %>
           <% if i == 0 %>
             <div class="item active">
           <% else %>
@@ -79,11 +76,10 @@
           <% if favorite_spot['photo'+i.to_s] == ""%>
           <%= image_tag("http://placehold.jp/24/cccccc/ffffff/250x50.png?text=画像が存在しません") %>
           <% else %>
-            <%= image_tag(url_for(:action => 'getImg', :photo_reference => favorite_spot['photo'+i.to_s]),:class => 'center-block')%>
+            <%= image_tag(url_for(:action => 'SpotImg', :photo_reference => favorite_spot['photo'+i.to_s]),:class => 'center-block')%>
           <% end %>
           <div class="carousel-caption"><%= favorite_spot['name'+i.to_s] %></div>
         </div>
-        <% i = i + 1 %>
         <% end %>
       </div>
       <!-- 前の画像へ戻るための矢印ポインタ -->

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,6 +13,9 @@
          <li><%= link_to 'プロフィール変更', edit_user_registration_path %></li>
        </ul>
        <ul class="nav navbar-nav navbar-left">
+         <li><%= link_to 'お気に入りスポット', favorite_spot_list_spot_search_index_path %></li>
+       </ul>
+       <ul class="nav navbar-nav navbar-left">
          <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
        </ul>
      </nav>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <script src="//maps.google.com/maps/api/js?key=<%= ENV['GOOGLE_API_KEY']   %>&libraries=places"></script>
+    <script src="//maps.google.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY']   %>&libraries=places"></script>
     <script src="//cdn.rawgit.com/mahnunchik/markerclustererplus/master/dist/markerclusterer.min.js"></script>
     <script src='//cdn.rawgit.com/printercu/google-maps-utility-library-v3-read-only/master/infobox/src/infobox_packed.js' type='text/javascript'></script>
 

--- a/app/views/spot_search/favorite_spot_list.html.erb
+++ b/app/views/spot_search/favorite_spot_list.html.erb
@@ -1,0 +1,23 @@
+<h4>お気に入りスポット</h4>
+<% params[:page] == nil ? i = 1 : i = 1 + (params[:page].to_i - 1) * @pageing_num %>
+<% if @favorite_spots_ary.count != 0 %>
+	<% @favorite_spots_ary.each do |favorite_spot| %>
+	<div class="media">
+		<a class="media-left" href="#">
+			<% if favorite_spot["photo"+i.to_s] == ""%>
+			<%= image_tag("http://placehold.jp/24/cccccc/ffffff/250x50.png?text=画像なし", :size => '100x100') %>
+			<% else %>
+				<%= image_tag(url_for(:action => 'getImg', :photo_reference => favorite_spot["photo"+i.to_s]), :size => '100x100')%>
+			<% end %>
+		</a>
+		<div class="media-body">
+			<h4 class="media-heading"><%= favorite_spot["name"+i.to_s]%></h4>
+			<%= favorite_spot["address"+i.to_s]%>
+		</div>
+	</div>
+	<% i = i+1 %>
+	<% end %>
+<% else %>
+	<p>１件もお気に入り登録がされていません</p>
+<% end %>
+<%= paginate @favorite_spots_ary %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   omniauth_callbacks: "omniauth_callbacks"}
   get 'home/index'
 
-  get 'home/getImg'
+  get 'home/SpotImg'
 
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   omniauth_callbacks: "omniauth_callbacks"}
   get 'home/index'
 
-  get 'home/show'
+  get 'home/getImg'
 
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     collection do
       get :list
       get :getImg
+      get :favorite_spot_list
     end
     member do
       get :select


### PR DESCRIPTION
お気に入り画面を作らないとか言っていましたが、
最初のログイン前のHOME画面で見栄えをよくするため、実装いたしました。
今回の修正では以下の３点行っています。
ご確認お願いいたします。

⑴ログイン前のHOME画面でユーザ問わず最新登録された３件と、ユーザ問わずお気に入り登録されたスポットを最大３件表示させるように実装

⑵ログイン後のヘッダーにお気に入りスポットのリンクを作成
対象ユーザのお気に入りスポットを１０件ずつ表示
→ページングで遷移、お気に入りの変更はスポット一覧で可能

※謝って現状２件でページングされるようになっていますが、次の段階で修正します

⑶管理者側のスポット部分を追加
→データ変更や管理をしたかったため追加しましたが、
ちゃんとした修正は別の機会に修正予定