### PR TITLE
issues#16 admin create

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -10,6 +10,14 @@ ActiveAdmin.register AdminUser do
     column :created_at
     actions
   end
+  show do
+    attributes_table do
+      row :id
+      row :email
+      row :current_sign_in_at
+      row :sign_in_count
+    end
+  end
 
   filter :email
   filter :current_sign_in_at

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,33 +1,42 @@
 ActiveAdmin.register_page "Dashboard" do
-
+  page_action :transmit, method: :post
   menu priority: 1, label: proc{ I18n.t("active_admin.dashboard") }
 
   content title: proc{ I18n.t("active_admin.dashboard") } do
-    div class: "blank_slate_container", id: "dashboard_default_message" do
-      span class: "blank_slate" do
-        span I18n.t("active_admin.dashboard_welcome.welcome")
-        small I18n.t("active_admin.dashboard_welcome.call_to_action")
+    panel "Recent Posts" do
+       ul do
+        notifications.map do |notification|
+          li "内容：" + notification.content + " 送信先ユーザ：" + notification.user.try(:username)
+        end
       end
     end
-
-    # Here is an example of a simple dashboard with columns and panels.
-    #
-    # columns do
-    #   column do
-    #     panel "Recent Posts" do
-    #       ul do
-    #         Post.recent(5).map do |post|
-    #           li link_to(post.title, admin_post_path(post))
-    #         end
-    #       end
-    #     end
-    #   end
-
-    #   column do
-    #     panel "Info" do
-    #       para "Welcome to ActiveAdmin."
-    #     end
-    #   end
-    # end
+    render "partial_form"
   end # content
+
+  controller do
+    def index
+      @users = User.all
+      @user = User.find(current_admin_user.id)
+      @notifications = @user.notifications_of_to_user.where(introduce_flg: false).limit(5)
+    end
+    def transmit
+      @user = User.find_by(id: params[:user]);
+      if @user != nil
+        if @user.notifications_of_from_user.create!(user_id: @user.id,opponent_user_id: current_admin_user.id,introduce_flg: false, content:params[:text_field] )
+          Pusher['user' + @user.id.to_s + 'channel'].trigger('push_created', {
+            message: "管理者から通知です"
+          })
+
+          flash[:success] = "通知を送信しました"
+          redirect_to admin_dashboard_path
+        else
+          logger.error("通知送信に失敗しました")
+          redirect_to admin_dashboard_path
+        end
+      else
+        flash[:error] = "対象ユーザがいません"
+        redirect_to admin_dashboard_path
+      end
+    end
+  end
 end

--- a/app/admin/notifications.rb
+++ b/app/admin/notifications.rb
@@ -1,0 +1,60 @@
+ActiveAdmin.register Notification do
+config.per_page = 10
+actions :index, :show
+# See permitted parameters documentation:
+# https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+#
+# permit_params :list, :of, :attributes, :on, :model
+#
+# or
+#
+# permit_params do
+#   permitted = [:permitted, :attributes]
+#   permitted << :other if params[:action] == 'create' && current_user.admin?
+#   permitted
+# end
+# 一覧ページの検索条件
+filter :user_id, label: '送信元ユーザ', as: :select, collection: User.all.map { |a| [a.username, a.id] }
+filter :opponent_user_id, label: '送信先ユーザ', as: :select, collection: User.all.map { |a| [a.username, a.id] }
+filter :content
+filter :read_flg
+filter :introduce_flg
+remove_filter :created_at, :updated_at
+# 一覧ページ
+  index do
+    column :id
+    column :content
+    column :read_flg
+    column :introduce_flg
+    column :user_id do |notification|
+      if notification.opponent_user_id != nil
+        User.find(notification.opponent_user_id).username
+      end
+    end
+    column :opponent_user_id do |notification|
+      if notification.user_id != nil
+        User.find(notification.user_id).username
+      end
+    end
+    actions
+  end
+  show do
+    attributes_table do
+      row :id
+      row :content
+      row :read_flg
+      row :introduce_flg
+      row :user_id do |notification|
+        if notification.opponent_user_id != nil
+          User.find(notification.opponent_user_id).username
+        end
+      end
+      row :opponent_user_id do |notification|
+        if notification.user_id != nil
+          User.find(notification.user_id).username
+        end
+      end
+    end
+  end
+
+end

--- a/app/admin/schedule_each_dates.rb
+++ b/app/admin/schedule_each_dates.rb
@@ -1,0 +1,61 @@
+ActiveAdmin.register ScheduleEachDate do
+# See permitted parameters documentation:
+config.per_page = 10
+actions :index, :show
+#https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+#
+# permit_params :list, :of, :attributes, :on, :model
+#
+# or
+#
+# permit_params do
+#   permitted = [:permitted, :attributes]
+#   permitted << :other if params[:action] == 'create' && current_user.admin?
+#   permitted
+# end
+# 一覧ページの検索条件
+filter :user_id, label: 'ユーザ', as: :select, collection: User.all.map { |a| [a.username, a.id] }
+filter :schedule_id, label: '対象スケジュール', as: :select, collection: Schedule.all.map { |a| [a.title, a.id] }
+filter :sche_date
+remove_filter :created_at, :updated_at,:schedule_each_times
+# 一覧ページ
+  index do
+    column :id
+    column :sche_date do |schedule_each_date|
+      if schedule_each_date.sche_date != nil
+        schedule_each_date.sche_date.strftime('%Y/%m/%d')
+      end
+    end
+    column :schedule_id do |schedule_each_date|
+      if schedule_each_date.schedule_id != nil
+        Schedule.find(schedule_each_date.schedule_id).title
+      end
+    end
+    column :user_id do |schedule_each_date|
+      if schedule_each_date.user_id != nil
+        User.find(schedule_each_date.user_id).username
+      end
+    end
+    actions
+  end
+  show do
+    attributes_table do
+      row :id
+      row :sche_date do |schedule_each_date|
+        if schedule_each_date.sche_date != nil
+          schedule_each_date.sche_date.strftime('%Y/%m/%d')
+        end
+      end
+      row :schedule_id do |schedule_each_date|
+        if schedule_each_date.schedule_id != nil
+          Schedule.find(schedule_each_date.schedule_id).title
+        end
+      end
+      row :user_id do |schedule_each_date|
+        if schedule_each_date.user_id != nil
+          User.find(schedule_each_date.user_id).username
+        end
+      end
+    end
+  end
+end

--- a/app/admin/schedule_each_times.rb
+++ b/app/admin/schedule_each_times.rb
@@ -1,0 +1,88 @@
+ActiveAdmin.register ScheduleEachTime do
+# See permitted parameters documentation:
+config.per_page = 10
+actions :index, :show
+#https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+#
+# permit_params :list, :of, :attributes, :on, :model
+#
+# or
+#
+# permit_params do
+#   permitted = [:permitted, :attributes]
+#   permitted << :other if params[:action] == 'create' && current_user.admin?
+#   permitted
+# end
+# 一覧ページの検索条件
+filter :user_id, label: 'ユーザ', as: :select, collection: User.all.map { |a| [a.username, a.id] }
+filter :schedule_id, label: '対象スケジュール', as: :select, collection: Schedule.all.map { |a| [a.title, a.id] }
+filter :place_id, as: :select, collection: Spot.all.map { |a| [a.name, a.id] }
+filter :memo
+remove_filter :created_at, :updated_at,:schedule_each_date_id
+# 一覧ページ
+  index do
+    column :id
+    column :from_time do |schedule_each_time|
+      schedule_each_time.from_time.strftime('%H:%M')
+    end
+    column :to_time do |schedule_each_time|
+      schedule_each_time.to_time.strftime('%H:%M')
+    end
+    column :memo
+    column :schedule_id do |schedule_each_time|
+      if schedule_each_time.schedule_id != nil
+        Schedule.find(schedule_each_time.schedule_id).title
+      end
+    end
+    column :schedule_each_date_id do |schedule_each_time|
+      if schedule_each_time.schedule_each_date_id != nil
+        ScheduleEachDate.find(schedule_each_time.schedule_each_date_id).sche_date.strftime('%Y/%m/%d')
+      end
+    end
+    column :user_id do |schedule_each_time|
+      if schedule_each_time.user_id != nil
+        User.find(schedule_each_time.user_id).username
+      end
+    end
+    column :place_id do |schedule_each_time|
+      if schedule_each_time.place_id != nil
+        Spot.find(schedule_each_time.place_id).name
+      end
+    end
+    actions
+  end
+  show do
+    attributes_table do
+      row :id
+      row :from_time do |schedule_each_time|
+        schedule_each_time.from_time.strftime('%H:%M')
+      end
+      row :to_time do |schedule_each_time|
+        schedule_each_time.to_time.strftime('%H:%M')
+      end
+      row :memo
+      row :schedule_id do |schedule_each_time|
+        if schedule_each_time.schedule_id != nil
+          Schedule.find(schedule_each_time.schedule_id).title
+        end
+      end
+      row :schedule_each_date_id do |schedule_each_time|
+        if schedule_each_time.schedule_each_date_id != nil
+          ScheduleEachDate.find(schedule_each_time.schedule_each_date_id).sche_date.strftime('%Y/%m/%d')
+        end
+      end
+      row :user_id do |schedule_each_time|
+        if schedule_each_time.user_id != nil
+          User.find(schedule_each_time.user_id).username
+        end
+      end
+      row :place_id do |schedule_each_time|
+        if schedule_each_time.place_id != nil
+          Spot.find(schedule_each_time.place_id).name
+        end
+      end
+    end
+  end
+
+
+end

--- a/app/admin/schedules.rb
+++ b/app/admin/schedules.rb
@@ -1,16 +1,41 @@
 ActiveAdmin.register Schedule do
-# See permitted parameters documentation:
-# https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-#
-# permit_params :list, :of, :attributes, :on, :model
-#
-# or
-#
-# permit_params do
-#   permitted = [:permitted, :attributes]
-#   permitted << :other if params[:action] == 'create' && current_user.admin?
-#   permitted
-# end
-  permit_params :user_id, :from_date, :to_date, :title, :memo
+ config.per_page = 10
+ actions :index, :show
+# 一覧ページの検索条件
+filter :user_id, label: 'ユーザ', as: :select, collection: User.all.map { |a| [a.username, a.id] }
+filter :from_date
+filter :to_date
+filter :title
+filter :memo
+remove_filter :created_at, :updated_at,:schedule_each_dates
+# 一覧ページ
+  index do
+    column :id
+    column :title
+    column :memo
+    column :from_date
+    column :to_date
+    column :user_id do |schedule|
+      if schedule.user_id != nil
+        User.find(schedule.user_id).username
+      end
+    end
+    actions
+  end
+  # 詳細ページ
+  show do
+    attributes_table do
+      row :id
+      row :title
+      row :memo
+      row :from_date
+      row :to_date
+      row :user_id do |schedule|
+        if schedule.user_id != nil
+          User.find(schedule.user_id).username
+        end
+      end
+    end
+  end
 
 end

--- a/app/admin/social_profiles.rb
+++ b/app/admin/social_profiles.rb
@@ -1,0 +1,43 @@
+ActiveAdmin.register SocialProfile do
+# See permitted parameters documentation:
+config.per_page = 10
+actions :index, :show #https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+#
+# permit_params :list, :of, :attributes, :on, :model
+#
+# or
+#
+# permit_params do
+#   permitted = [:permitted, :attributes]
+#   permitted << :other if params[:action] == 'create' && current_user.admin?
+#   permitted
+# end
+# 一覧ページの検索条件
+filter :user_id, label: 'ユーザ', as: :select, collection: User.all.map { |a| [a.username, a.id] }
+filter :provider
+remove_filter :created_at, :updated_at,:uid
+# 一覧ページ
+  index do
+    column :id
+    column :provider
+    column :user_id do |social_profile|
+      if social_profile.user_id != nil
+        User.find(social_profile.user_id).username
+      end
+    end
+    actions
+  end
+  show do
+    attributes_table do
+      row :id
+      row :provider
+      row :user_id do |social_profile|
+        if social_profile.user_id != nil
+          User.find(social_profile.user_id).username
+        end
+      end
+    end
+  end
+
+
+end

--- a/app/admin/spots.rb
+++ b/app/admin/spots.rb
@@ -1,27 +1,38 @@
 ActiveAdmin.register Spot do
-# See permitted parameters documentation:
-# https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-#
-# permit_params :list, :of, :attributes, :on, :model
-#
-# or
-#
-# permit_params do
-#   permitted = [:permitted, :attributes]
-#   permitted << :other if params[:action] == 'create' && current_user.admin?
-#   permitted
-# end
-permit_params :name, :address, :place_id, :favorite_flg
-form do |f|
-    inputs  do
-      input :name
-      input :address
-      input :name
-      input :place_id
-      input :favorite_flg
+  config.per_page = 10
+  actions :index, :show
+#一覧ページの検索条件
+filter :user_id, label: 'ユーザ', as: :select, collection: User.all.map { |a| [a.username, a.id] }
+filter :name
+filter :favorite_flg
+remove_filter :created_at, :updated_at,:latitude,:longitude,:address
+# 一覧ページ
+  index do
+    column :id
+    column :name
+    column :address
+    column :place_id
+    column :user_id do |spot|
+      if spot.user_id != nil
+        User.find(spot.user_id).username
+      end
     end
-
+    column :favorite_flg
     actions
   end
-
+  # 詳細ページ
+  show do
+    attributes_table do
+      row :id
+      row :name
+      row :address
+      row :place_id
+      row :user_id do |spot|
+        if spot.user_id != nil
+          User.find(spot.user_id).username
+        end
+      end
+      row :favorite_flg
+    end
+  end
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,15 +1,22 @@
 ActiveAdmin.register User do
-# See permitted parameters documentation:
-# https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
-#
-# permit_params :list, :of, :attributes, :on, :model
-#
-# or
-#
-# permit_params do
-#   permitted = [:permitted, :attributes]
-#   permitted << :other if params[:action] == 'create' && current_user.admin?
-#   permitted
-# end
-
+  config.per_page = 10
+  actions :index, :show
+# 一覧ページの検索条件
+filter :email
+filter :username
+# 一覧ページ
+  index do
+    column :id
+    column :email
+    column :username
+    actions
+  end
+  # 詳細ページ
+  show do
+    attributes_table do
+      row :id
+      row :email
+      row :username
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,11 +5,16 @@ class ApplicationController < ActionController::Base
   before_action :current_notifications, if: :signed_in?
 
   def after_sign_in_path_for(resource)
+    stored_location_for(resource) ||
+    if resource.is_a?(User)
       travel_planning_index_path
+    else
+      super
+    end
   end
   def current_notifications
-     @notifications_count = Notification.where(user_id: current_user.id).where(read_flg: false).count
-   end
+       @notifications_count = Notification.where(user_id: current_user).where(read_flg: false).count
+    end
   protected
     def sign_in_required
         redirect_to new_user_session_url unless user_signed_in?

--- a/app/controllers/notification_controller.rb
+++ b/app/controllers/notification_controller.rb
@@ -10,8 +10,14 @@ class NotificationController < ApplicationController
   end
 
   def show
-    @spots = Spot.where(user_id:params[:user_id])
-    @schedules = Schedule.includes(:schedule_each_dates => :schedule_each_times).find_by(user_id:params[:user_id] ,id:params[:schedule_id])
+    #招待の通知内容を確認する場合
+    if params[:content] == nil
+      @spots = Spot.where(user_id:params[:user_id])
+      @schedules = Schedule.includes(:schedule_each_dates => :schedule_each_times).find_by(user_id:params[:user_id] ,id:params[:schedule_id])
+    #通常の通知内容を確認する場合
+    else
+      @content = params[:content]
+    end
   end
   def update
     notification = current_user.notifications_of_from_user.find(params[:notification_id])

--- a/app/views/admin/dashboard/_partial_form.html.erb
+++ b/app/views/admin/dashboard/_partial_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_tag({ action: :transmit }, { method: :post }) do %>
+<div class="field">
+  <%= label_tag 'ユーザ' %>
+  <%= select_tag('user',options_from_collection_for_select(@users,:id,:username), {class: 'form-control'}) %><br/>
+</div>
+<div class="field">
+  <%= label_tag '内容'  %>
+  <%= text_field_tag :text_field,'' ,class:"form-control" %><br/>
+</div>
+<div class="actions">
+  <%= submit_tag '通知を送る', class: 'btn btn-primary' %>
+</div>
+<% end %>

--- a/app/views/notification/index.html.erb
+++ b/app/views/notification/index.html.erb
@@ -10,8 +10,13 @@
    <hr>
      <li>
        <p>
+         <% if notification.introduce_flg == false %>
+          管理者からの通知が届いています
+          <%=  link_to "確認する" ,notification_path(notification,params: {content:notification.content })   %>
+         <% else %>
            <%= notification.opponent_user.try(:username) %>さんから旅行計画の招待が来ています
            <%=  link_to "確認する" ,notification_path(notification,params: {user_id: notification.opponent_user.id, schedule_id:notification.content.to_i })   %>
+         <% end %>
            <% if notification.read_flg == false %>
              <%=  link_to "既読にする" ,notification_path(notification, params: {notification_id: notification.id,read_flg:true }), :method => :put  %>
            <% else %>

--- a/app/views/notification/show.html.erb
+++ b/app/views/notification/show.html.erb
@@ -1,30 +1,41 @@
 <h1>お知らせ詳細</h1>
 
-<button type="button" class="btn pull-right btn-lg btn-default">
+<button type="button" class="btn btn-lg btn-default">
   <%= link_to '戻る', :back,data: {"turbolinks" => false} %>
 </button>
 
-<h2><%= @schedules.title %></h2>
+<% if @content != nil%>
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      管理者からの連絡
+    </div>
+    <div class="panel-body">
+      <%= @content %>
+    </div>
+  </div>
+<% else %>
+  <h2><%= @schedules.title %></h2>
 
-<div class="panel panel-default">
-  <% @schedules.schedule_each_dates.each do |schedule_each_date| %>
-  <div class="panel-heading">
-          <%= schedule_each_date.sche_date.strftime('%Y/%m/%d') %>
-	</div>
-	<div class="panel-body">
-    <% if schedule_each_date.schedule_each_times.count == 0 %>
-      <p>スケジュール時間帯がまだ登録されていません</p>
-    <% end %>
-    <ul class="list-group">
-      <% schedule_each_date.schedule_each_times.each do |schedule_each_time| %>
-        <li class="list-group-item">
-          滞在時間:<%= schedule_each_time.from_time.strftime('%H:%M') %>〜<%= schedule_each_time.to_time.strftime('%H:%M') %>&nbsp;
-          メモ:<%= schedule_each_time.memo %></br>
-          場所:<%= select_tag :place, options_from_collection_for_select(@spots, :id, :name,schedule_each_time.place_id), disabled: true %>&nbsp;
-          <%= link_to '場所を確認する', spot_search_path(schedule_each_time.place_id) %>
-        </li>
+  <div class="panel panel-default">
+    <% @schedules.schedule_each_dates.each do |schedule_each_date| %>
+    <div class="panel-heading">
+            <%= schedule_each_date.sche_date.strftime('%Y/%m/%d') %>
+  	</div>
+  	<div class="panel-body">
+      <% if schedule_each_date.schedule_each_times.count == 0 %>
+        <p>スケジュール時間帯がまだ登録されていません</p>
       <% end %>
-    </ul>
-	</div>
-  <% end %>
-</div>
+      <ul class="list-group">
+        <% schedule_each_date.schedule_each_times.each do |schedule_each_time| %>
+          <li class="list-group-item">
+            滞在時間:<%= schedule_each_time.from_time.strftime('%H:%M') %>〜<%= schedule_each_time.to_time.strftime('%H:%M') %>&nbsp;
+            メモ:<%= schedule_each_time.memo %></br>
+            場所:<%= select_tag :place, options_from_collection_for_select(@spots, :id, :name,schedule_each_time.place_id), disabled: true %>&nbsp;
+            <%= link_to '場所を確認する', spot_search_path(schedule_each_time.place_id) %>
+          </li>
+        <% end %>
+      </ul>
+  	</div>
+    <% end %>
+  </div>
+<% end %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -145,7 +145,7 @@ ActiveAdmin.setup do |config|
   # You can add before, after and around filters to all of your
   # Active Admin resources and pages from here.
   #
-  # config.before_action :do_something_awesome
+   config.before_action :current_notifications
 
   # == Localize Date/Time Format
   #
@@ -153,7 +153,7 @@ ActiveAdmin.setup do |config|
   # To understand how to localize your app with I18n, read more at
   # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
   #
-  config.localize_format = :long
+  config.localize_format = :default
 
   # == Setting a Favicon
   #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,6 +8,10 @@ ja:
       schedule_each_date: スケジュール日付別
       schedule_each_time: スケジュール時間帯別
       user: ユーザ
+      schedule: スケジュール
+      spot: スポット
+      social_profile: プロファイル
+      notification: 通知
     attributes:
       admin_user:
         email: メールアドレス
@@ -26,6 +30,39 @@ ja:
         updated_at: 更新日時
       user:
         username: 名前
+      schedule:
+        title: タイトル
+        memo: メモ
+        from_date: 滞在開始日
+        to_date: 滞在終了日
+        user_id: ユーザ
+      schedule_each_date:
+        sche_date: スケジュール日付
+        schedule_id: 対象スケジュール名
+        user_id: ユーザ
+      schedule_each_time:
+        from_time: 滞在開始時間
+        to_time: 滞在終了時間
+        memo: メモ
+        schedule_id: 対象スケジュール名
+        schedule_each_date_id: スケジュール日付
+        user_id: ユーザ
+        place_id: スポット
+      spot:
+        name: スポット名
+        address: 住所
+        place_id: GooglePlaceID
+        user_id: ユーザ
+        favorite_flg: お気に入りフラグ
+      social_profile:
+        provider: SNS名
+        user_id: ユーザ
+      notification:
+        content: 内容
+        read_flg: 既読フラグ
+        introduce_flg: 招待フラグ
+        user_id: 送信元ユーザ
+        opponent_user_id: 送信先ユーザ
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"


### PR DESCRIPTION
管理者側の画面をまとめて作成
⑴各モデルでは一覧と詳細画面での確認のみとしました
→created_atなどの必要なさそうなものは表示させないように修正
→管理者ユーザの作成は他ではできないため、登録、更新、削除も可能
⑵ダッシュボード画面で特定ユーザにブラウザ通知を送れるように修正
→管理者ユーザを、通常のUserテーブルのidが１のユーザとしてみなし、Notificationテーブルに登録させるようにしました
⑶通知テーブルで管理者からの通知を一覧に表示、詳細画面で確認できるように修正