### PR TITLE
issues#14 uploader create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ config/environments/*.local.yml
 # .gitignore
 .env
 .DS_Store
+/public

--- a/app/controllers/travel_planning_date_controller.rb
+++ b/app/controllers/travel_planning_date_controller.rb
@@ -1,9 +1,40 @@
 require "date"
 class TravelPlanningDateController < ApplicationController
   def index
-    @schedule_id = params[:schedule_id]
+    #画像アップロードでエラーがでてきたときや画面更新した時のためにセッションに格納
+    session[:schedule_id] = params[:schedule_id]
+    @schedule_id = session[:schedule_id]
     respond_to do |format|
       format.html
     end
+  end
+  def upload_prepare
+    @schedule = Schedule.includes(:thumbnails).order("thumbnails.created_at").find(session[:schedule_id])
+    #画像が0件の時に作成
+    if @schedule.thumbnails.empty?
+      @schedule.thumbnails.new(schedule_id: @schedule.id, user_id:@schedule.user_id)
+    end
+  end
+  def upload
+    #1件でも登録しようとした場合や既存データがあり全て削除した場合
+    if params[:schedule] != nil
+      @schedule = Schedule.find(params[:schedule][:thumbnails_attributes]["0"]["schedule_id"])
+      if @schedule.update(thumbnail_params)
+        flash[:success] = "画像を登録しました"
+        redirect_to travel_planning_date_upload_prepare_path
+      else
+        flash[:error] = "画像の登録に失敗しました"
+        render :upload_prepare
+      end
+    #初めて登録する際に、フォームを全て削除した状態で登録ボタンを押された場合
+    else
+      @schedule = Schedule.find(session[:schedule_id])
+      flash[:error] = "画像の登録に失敗しました"
+      redirect_to travel_planning_date_upload_prepare_path
+    end
+  end
+  private
+  def thumbnail_params
+    params.require(:schedule).permit(:id, thumbnails_attributes: [:id,:schedule_id, :user_id,:image,:image_cache, :_destroy])
   end
 end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -2,6 +2,8 @@ require 'date'
 class Schedule < ApplicationRecord
   belongs_to :user
   has_many :schedule_each_dates,dependent: :destroy
+  has_many :thumbnails,dependent: :destroy, inverse_of: :schedule
+  accepts_nested_attributes_for :thumbnails, reject_if: :all_blank, allow_destroy: true
   validates :title, presence: true,length: { maximum: 100 }
   validates :from_date, presence: true, date: true
   validates :to_date, presence: true, date: true

--- a/app/models/thumbnail.rb
+++ b/app/models/thumbnail.rb
@@ -1,0 +1,10 @@
+class Thumbnail < ApplicationRecord
+  include ActiveModel::Validations
+  belongs_to :schedule
+  mount_uploader :image, ImageUploader
+  validates :image,
+    :presence => true,
+    :file_size => {
+        :maximum => 1.megabytes.to_i
+    }
+end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,8 +5,8 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  #storage :file
-   storage :fog
+  storage :file
+  # storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
@@ -14,6 +14,20 @@ class ImageUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
+  include CarrierWave::MiniMagick
+  def size_range
+   1.kilobyte..1.megabytes
+  end
+  process :resize_to_fit => [200,200]
+
+  version :thumb do
+    process :resize_to_fit => [50,50]
+  end
+
+ # jpg,jpeg,gif,pngしか受け付けない
+ def extension_white_list
+   %w(jpg jpeg gif png)
+ end
   # Provide a default URL as a default if there hasn't been a file uploaded:
   # def default_url(*args)
   #   # For Rails 3.1+ asset pipeline compatibility:

--- a/app/validators/file_size_validator.rb
+++ b/app/validators/file_size_validator.rb
@@ -1,0 +1,65 @@
+class FileSizeValidator < ActiveModel::EachValidator
+  MESSAGES  = { :is => :wrong_size, :minimum => :size_too_small, :maximum => :size_too_big }.freeze
+  CHECKS    = { :is => :==, :minimum => :>=, :maximum => :<= }.freeze
+
+  DEFAULT_TOKENIZER = lambda { |value| value.split(//) }
+  RESERVED_OPTIONS  = [:minimum, :maximum, :within, :is, :tokenizer, :too_short, :too_long]
+
+  def initialize(options)
+    if range = (options.delete(:in) || options.delete(:within))
+      raise ArgumentError, ":in and :within must be a Range" unless range.is_a?(Range)
+      options[:minimum], options[:maximum] = range.begin, range.end
+      options[:maximum] -= 1 if range.exclude_end?
+    end
+
+    super
+  end
+
+  def check_validity!
+    keys = CHECKS.keys & options.keys
+
+    if keys.empty?
+      raise ArgumentError, 'Range unspecified. Specify the :within, :maximum, :minimum, or :is option.'
+    end
+
+    keys.each do |key|
+      value = options[key]
+
+      unless value.is_a?(Integer) && value >= 0
+        raise ArgumentError, ":#{key} must be a nonnegative Integer"
+      end
+    end
+  end
+
+  def validate_each(record, attribute, value)
+    raise(ArgumentError, "A CarrierWave::Uploader::Base object was expected") unless value.kind_of? CarrierWave::Uploader::Base
+
+    value = (options[:tokenizer] || DEFAULT_TOKENIZER).call(value) if value.kind_of?(String)
+
+    CHECKS.each do |key, validity_check|
+      next unless check_value = options[key]
+
+      value ||= [] if key == :maximum
+
+      value_size = value.size
+      next if value_size.send(validity_check, check_value)
+
+      errors_options = options.except(*RESERVED_OPTIONS)
+      errors_options[:file_size] = help.number_to_human_size check_value
+
+      default_message = options[MESSAGES[key]]
+      errors_options[:message] ||= default_message if default_message
+
+      record.errors.add(attribute, MESSAGES[key], errors_options)
+    end
+  end
+
+  def help
+    Helper.instance
+  end
+
+  class Helper
+    include Singleton
+    include ActionView::Helpers::NumberHelper
+  end
+end

--- a/app/views/notification/show.html.erb
+++ b/app/views/notification/show.html.erb
@@ -37,5 +37,15 @@
       </ul>
   	</div>
     <% end %>
+    <% if @schedules.thumbnails.count != 0 %>
+      <div class="panel-footer">
+      <h4>画像</h4>
+      <% @schedules.thumbnails.each do |thumbnail| %>
+      <% if thumbnail.image? %>
+            <%= image_tag thumbnail.image.url %>
+          <% end %>
+      <% end %>
+    </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/travel_planning/_index.html.erb
+++ b/app/views/travel_planning/_index.html.erb
@@ -15,7 +15,7 @@
       <% end %>
     </td>
     <td class="">
-      <%= link_to  travel_planning_date_index_path(:schedule_id => schedule.id) do  %>
+      <%= link_to  travel_planning_date_index_path(:schedule_id => schedule.id),data: {"turbolinks" => false} do  %>
         <i class="glyphicon glyphicon-calendar" aria-hidden="true"></i>
       <% end %>
     </td>

--- a/app/views/travel_planning_date/_index.html.erb
+++ b/app/views/travel_planning_date/_index.html.erb
@@ -1,5 +1,10 @@
-<%= link_to  travel_planning_index_path(),data: {"turbolinks" => false} do  %>
-  <i class="glyphicon glyphicon-backward"> 戻る</i>
-<% end %>
+<button type="button" class="btn btn-lg btn-default">
+  <%= link_to "戻る",travel_planning_index_path,data: {"turbolinks" => false} %>
+</button>
+
+<button type="button" class="btn btn-lg btn-default">
+  <%= link_to "画像をアップロードする",travel_planning_date_upload_prepare_path  %>
+</button>
+
 <div id="calendar" class="bottom"></div>
 <%= hidden_field_tag :schedule_id, @schedule_id %>

--- a/app/views/travel_planning_date/_thumbnail_fields.html.erb
+++ b/app/views/travel_planning_date/_thumbnail_fields.html.erb
@@ -1,0 +1,11 @@
+<div class='nested-fields'>
+  <div class="field">
+    <%= f.label :image %>
+    <%= f.file_field :image %>
+    <%= f.hidden_field :image_cache %>
+  </div>
+  <%= f.hidden_field :user_id, :value => @schedule.user_id %>
+  <%= f.hidden_field :schedule_id, :value => @schedule.id %>
+  <%= hidden_field_tag :schedule_id, @schedule.id  %>
+  <%= link_to_remove_association "画像を削除する", f %>
+</div>

--- a/app/views/travel_planning_date/upload_prepare.html.erb
+++ b/app/views/travel_planning_date/upload_prepare.html.erb
@@ -1,0 +1,42 @@
+<% flash_messages %>
+<% if @schedule.errors.any? %>
+<div class="alert alert-danger">
+  <% @schedule.errors.full_messages.each do |msg| %>
+    <li><%= msg %></li>
+  <% end %>
+</div>
+<% end %>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h4>旅行画像登録</h4>
+  </div>
+  <div class="panel-body">
+    <%= form_for(@schedule,:url => {:controller => :travel_planning_date,:action => :upload}, :html => {:multipart => true} ) do |f| %>
+      <div id="detail-association-insertion-point">
+        <%= f.fields_for :thumbnails do |thumbnail| %>
+            <%= render 'thumbnail_fields', :f => thumbnail ,schedule: @schedule %>
+        <% end %>
+      </div>
+      <%= link_to_add_association "画像を新規追加",f, :thumbnails,
+        partial: 'thumbnail_fields',
+        data: { association_insertion_method: 'append',
+        association_insertion_node: '#detail-association-insertion-point' } %>
+       <%= f.submit "登録する" %>
+    <% end %>
+  </div>
+</div>
+
+<button type="button" class="btn btn-default">
+  <%= link_to '戻る',travel_planning_date_index_path(:schedule_id => @schedule.id),data: {"turbolinks" => false} %>
+</button>
+
+<h4>登録した画像</h4>
+<% if @schedule.thumbnails.count != 0%>
+  <% @schedule.thumbnails.each do |thumbnail| %>
+    <% if thumbnail.image? %>
+      <%= image_tag thumbnail.image.url %>
+    <% end %>
+  <% end %>
+<% else %>
+  <p>１件も登録がありません</p>
+<% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,7 @@ ja:
       spot: スポット
       social_profile: プロファイル
       notification: 通知
+      thumbnail: 画像
     attributes:
       admin_user:
         email: メールアドレス
@@ -63,6 +64,10 @@ ja:
         introduce_flg: 招待フラグ
         user_id: 送信元ユーザ
         opponent_user_id: 送信先ユーザ
+      thumbnail:
+        image: 画像
+      schedule/thumbnails:
+        image: 画像
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"
@@ -171,6 +176,7 @@ ja:
   errors:
     format: "%{attribute}%{message}"
     messages:
+      max_size_error: "画像ファイルのサイズが大きすぎます"
       accepted: を受諾してください
       blank: を入力してください
       present: は入力しないでください

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,10 @@ Rails.application.routes.draw do
 
   resources :travel_planning, only:[:create,:new,:edit,:update,:destroy,:index]
   resources :travel_planning_date, only:[:index]
+  get 'travel_planning_date/upload' => 'travel_planning_date#upload_prepare'
+  post 'travel_planning_date/upload' =>  'travel_planning_date#upload'
+  patch 'travel_planning_date/upload' =>  'travel_planning_date#upload'
+  get 'travel_planning_date/upload_prepare'
   resources :travel_planning_time, only:[:show,:update]do
     collection do
       get :show_spot_roting

--- a/db/migrate/20171230065214_create_thumbnails.rb
+++ b/db/migrate/20171230065214_create_thumbnails.rb
@@ -1,0 +1,11 @@
+class CreateThumbnails < ActiveRecord::Migration[5.1]
+  def change
+    create_table :thumbnails do |t|
+      t.integer :schedule_id
+      t.integer :user_id
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171227020152) do
+ActiveRecord::Schema.define(version: 20171230065214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,14 @@ ActiveRecord::Schema.define(version: 20171227020152) do
     t.string "place_id"
     t.integer "user_id"
     t.boolean "favorite_flg"
+  end
+
+  create_table "thumbnails", force: :cascade do |t|
+    t.integer "schedule_id"
+    t.integer "user_id"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
複数画像アップロード機能を作成しました。
今回は以下２点の修正です

⑴旅行画像アップロード画面作成
・一つの旅行で画像を複数登録できるように対応
※画像は必須項目
※動的に増やせるフォームで対応
→スケジュール日付別のカレンダー上から旅行画像アップロード画面へ遷移可能

⑵旅行計画に招待された場合の通知内容詳細画面で登録された画像を表示できるように修正
